### PR TITLE
ux : fixed textfield appearance on validation error

### DIFF
--- a/lib/views/screens/login_screen.dart
+++ b/lib/views/screens/login_screen.dart
@@ -45,8 +45,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   style: TextStyle(fontSize: UiSizes.size_25),
                 ),
                 SizedBox(height: UiSizes.height_15),
-                Container(
-                  height: UiSizes.height_66,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: UiSizes.height_4),
                   child: TextFormField(
                     validator: (value) => value!.isValidEmail()
                         ? null
@@ -66,8 +66,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   ),
                 ),
                 SizedBox(height: UiSizes.height_10),
-                Container(
-                  height: UiSizes.height_66,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: UiSizes.height_4),
                   child: Obx(
                     () => TextFormField(
                       controller: controller.passwordController,

--- a/lib/views/screens/signup_screen.dart
+++ b/lib/views/screens/signup_screen.dart
@@ -48,8 +48,8 @@ class _SignupScreenState extends State<SignupScreen> {
                   style: TextStyle(fontSize: UiSizes.size_25),
                 ),
                 SizedBox(height: UiSizes.height_15),
-                SizedBox(
-                  height: UiSizes.height_66,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: UiSizes.height_2),
                   child: TextFormField(
                     validator: (value) => value!.isValidEmail()
                         ? null
@@ -69,8 +69,8 @@ class _SignupScreenState extends State<SignupScreen> {
                   ),
                 ),
                 SizedBox(height: UiSizes.height_10),
-                SizedBox(
-                  height: UiSizes.height_66,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: UiSizes.height_2),
                   child: TextFormField(
                     style: TextStyle(fontSize: UiSizes.size_14),
                     validator: (value) => value!.isValidPassword()
@@ -91,8 +91,8 @@ class _SignupScreenState extends State<SignupScreen> {
                   ),
                 ),
                 SizedBox(height: UiSizes.height_10),
-                SizedBox(
-                  height: UiSizes.height_66,
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: UiSizes.height_2),
                   child: Obx(
                     () => TextFormField(
                       style: TextStyle(fontSize: UiSizes.size_14),


### PR DESCRIPTION
Fixed the appearance of text field in presence of any validation errors.

**Previous behavior**:
![Screenshot_20230914-183838](https://github.com/AOSSIE-Org/Resonate/assets/69506046/a26db836-f21e-493d-a5d2-2b86d3e0edb0)

**Current Behavior**:
![Screenshot_20230914-222242](https://github.com/AOSSIE-Org/Resonate/assets/69506046/48c1cec2-be03-4527-bc14-be04ecf2506c)