### PR TITLE
fix: confirm password field persists value on navigation

### DIFF
--- a/lib/views/screens/login_screen.dart
+++ b/lib/views/screens/login_screen.dart
@@ -194,6 +194,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       onTap: () {
                         controller.emailController.clear();
                         controller.passwordController.clear();
+                        controller.confirmPasswordController.clear();
                         Get.toNamed(AppRoutes.signup);
                       },
                       child: Text(


### PR DESCRIPTION
**Solution**
```dart
onTap: () {
                        controller.emailController.clear();
                        controller.passwordController.clear();
                        controller.confirmPasswordController.clear();
                        Get.toNamed(AppRoutes.signup);
                      },
```

Closes #156 