### PR TITLE
fix: Resolve typo mistake for landingThirdImage

### DIFF
--- a/lib/utils/app_images.dart
+++ b/lib/utils/app_images.dart
@@ -8,7 +8,7 @@ class AppImages {
   
   static const landingFirstImage = 'assets/images/landing_first.png';
   static const landingSecondImage = 'assets/images/landing_second.png';
-  static const landingThirdImage = 'assets/images/lading_third.png';
+  static const landingThirdImage = 'assets/images/landing_third.png';
 
 
   static const noConnectionImage = 'assets/images/no_connection.svg';


### PR DESCRIPTION
## Description

Correct the name of the landingThirdImage to match the name of the image in the assets/images 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Just run the app and make sure that you are not getting the following exception in the logs:
**The following assertion was thrown resolving an image codec:
Unable to load asset: "assets/images/lading_third.png".

Exception: Asset not found
When the exception was thrown, this was the stack: 
#0      PlatformAssetBundle.loadBuffer (package:flutter/src/services/asset_bundle.dart:369:7)
<asynchronous suspension>
#1      AssetBundleImageProvider._loadAsync (package:flutter/src/painting/image_provider.dart:811:18)** 

Please include screenshots below if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] Tag the PR with the appropriate labels