### PR TITLE
No room placeholder alignment fixed

### DIFF
--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -52,7 +52,7 @@ class HomeScreen extends StatelessWidget {
                             crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
                               SizedBox(
-                                height: UiSizes.height_12,
+                                height: UiSizes.height_140,
                               ),
                               Image.asset(
                                 AppImages.noRoomImage,


### PR DESCRIPTION
## Description
The Alignment of the no-room placeholder was not aligned to the center

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
<span>
Before
<img src="https://github.com/AOSSIE-Org/Resonate/assets/74780977/4376822c-2be3-4ef2-ba58-8e0eb689bb0a" width=200 />
After
<img src="https://github.com/AOSSIE-Org/Resonate/assets/74780977/3e7ffa70-01ef-4483-bcc1-9a8edcbe1a1f" width=200 />
</span>


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist
- [ ] Tag the PR with the appropriate labels