### PR TITLE
Added logic to delete old profile image as user add new profile image 

### DIFF
--- a/lib/controllers/auth_state_controller.dart
+++ b/lib/controllers/auth_state_controller.dart
@@ -70,7 +70,7 @@ class AuthStateController extends GetxController {
 
   Future<String> getAppwriteToken() async {
     Jwt authToken = await account.createJWT();
-    // print(authToken);
+    log(authToken.toString());
     return authToken.jwt;
   }
 

--- a/lib/controllers/auth_state_controller.dart
+++ b/lib/controllers/auth_state_controller.dart
@@ -16,6 +16,7 @@ class AuthStateController extends GetxController {
   var isInitializing = false.obs;
   late final Account account;
   late String? uid;
+  late String? profileImageID;
   late String? displayName;
   late String? email;
   late String? profileImageUrl;
@@ -56,6 +57,7 @@ class AuthStateController extends GetxController {
             collectionId: usersCollectionID,
             documentId: appwriteUser.$id);
         profileImageUrl = userDataDoc.data["profileImageUrl"];
+        profileImageID = userDataDoc.data["profileImageID"];
         userName = userDataDoc.data["username"] ?? "unavailable";
       }
       update();
@@ -68,7 +70,7 @@ class AuthStateController extends GetxController {
 
   Future<String> getAppwriteToken() async {
     Jwt authToken = await account.createJWT();
-    print(authToken);
+    // print(authToken);
     return authToken.jwt;
   }
 
@@ -81,7 +83,8 @@ class AuthStateController extends GetxController {
         Get.offNamed(AppRoutes.tabview);
       }
     } catch (e) {
-      bool? landingScreenShown = GetStorage().read("landingScreenShown"); // landingScreenShown is the boolean value that is used to check wether to show the user the onboarding screen or not on the first launch of the app.
+      bool? landingScreenShown = GetStorage().read(
+          "landingScreenShown"); // landingScreenShown is the boolean value that is used to check whether to show the user the onBoarding screen or not on the first launch of the app.
       landingScreenShown == null
           ? Get.offNamed(AppRoutes.landing)
           : Get.offNamed(AppRoutes.login);

--- a/lib/controllers/edit_profile_controller.dart
+++ b/lib/controllers/edit_profile_controller.dart
@@ -180,7 +180,7 @@ class EditProfileController extends GetxController {
           log(e.toString());
         }
 
-        uniqueIdForProfileImage =
+        uniqueIdForProfileImage = authStateController.uid! +
             DateTime.now().millisecondsSinceEpoch.toString();
 
         // Create new user profile picture file in Storage

--- a/lib/controllers/edit_profile_controller.dart
+++ b/lib/controllers/edit_profile_controller.dart
@@ -30,6 +30,7 @@ class EditProfileController extends GetxController {
 
   late String oldUsername;
   late String oldDisplayName;
+  late String uniqueIdForProfileImage;
 
   TextEditingController imageController = TextEditingController();
   TextEditingController nameController = TextEditingController();
@@ -171,10 +172,21 @@ class EditProfileController extends GetxController {
 
       // Update user PROFILE PICTURE
       if (profileImagePath != null) {
+        try {
+          await storage.deleteFile(
+              bucketId: userProfileImageBucketId,
+              fileId: authStateController.profileImageID!);
+        } catch (e) {
+          log(e.toString());
+        }
+
+        uniqueIdForProfileImage =
+            DateTime.now().millisecondsSinceEpoch.toString();
+
         // Create new user profile picture file in Storage
         final profileImage = await storage.createFile(
             bucketId: userProfileImageBucketId,
-            fileId: ID.unique(),
+            fileId: uniqueIdForProfileImage,
             file: InputFile.fromPath(
                 path: profileImagePath!,
                 filename: "${authStateController.email}.jpeg"));
@@ -189,6 +201,7 @@ class EditProfileController extends GetxController {
           documentId: authStateController.uid!,
           data: {
             "profileImageUrl": imageController.text,
+            "profileImageID": uniqueIdForProfileImage,
           },
         );
       }
@@ -213,7 +226,10 @@ class EditProfileController extends GetxController {
 
         if (!usernameAvail) {
           usernameAvailable.value = false;
-          customSnackbar("Username Unavailable!", "This username is invalid or either taken already.", MessageType.error);
+          customSnackbar(
+              "Username Unavailable!",
+              "This username is invalid or either taken already.",
+              MessageType.error);
           return;
         }
 
@@ -274,13 +290,16 @@ class EditProfileController extends GetxController {
       profileImagePath = null;
 
       // The Success snackbar is only shown when there is change made, otherwise it is not shown
-      if(showSuccessSnackbar){
-        customSnackbar('Profile updated', 'All changes are saved successfully.', MessageType.success);
-      }else{
+      if (showSuccessSnackbar) {
+        customSnackbar('Profile updated', 'All changes are saved successfully.',
+            MessageType.success);
+      } else {
         // This snackbar is to show user that profile is up to date and there are no changes done by user
-        customSnackbar('Profile is up to date', 'There are no new changes made, Nothing to save.', MessageType.info);
+        customSnackbar(
+            'Profile is up to date',
+            'There are no new changes made, Nothing to save.',
+            MessageType.info);
       }
-
     } catch (e) {
       log(e.toString());
       customSnackbar('Error!', e.toString(), MessageType.error);

--- a/lib/controllers/onboarding_controller.dart
+++ b/lib/controllers/onboarding_controller.dart
@@ -23,6 +23,7 @@ class OnboardingController extends GetxController {
 
   RxBool isLoading = false.obs;
   String? profileImagePath;
+  String? uniqueIdForProfileImage;
   TextEditingController nameController = TextEditingController();
   TextEditingController usernameController = TextEditingController();
   TextEditingController imageController =
@@ -60,7 +61,10 @@ class OnboardingController extends GetxController {
     var usernameAvail = await isUsernameAvailable(usernameController.text);
     if (!usernameAvail) {
       usernameAvailable.value = false;
-      customSnackbar("Username Unavailable!", "This username is invalid or either taken already.", MessageType.error);
+      customSnackbar(
+          "Username Unavailable!",
+          "This username is invalid or either taken already.",
+          MessageType.error);
       return;
     }
     try {
@@ -74,9 +78,12 @@ class OnboardingController extends GetxController {
           data: {"email": authStateController.email});
       //Update User Meta Data
       if (profileImagePath != null) {
+        uniqueIdForProfileImage =
+            DateTime.now().millisecondsSinceEpoch.toString();
+
         final profileImage = await storage.createFile(
             bucketId: userProfileImageBucketId,
-            fileId: ID.unique(),
+            fileId: uniqueIdForProfileImage!,
             file: InputFile.fromPath(
                 path: profileImagePath!,
                 filename: "${authStateController.email}.jpeg"));
@@ -95,7 +102,8 @@ class OnboardingController extends GetxController {
           "username": usernameController.text,
           "profileImageUrl": imageController.text,
           "dob": dobController.text,
-          "email": authStateController.email
+          "email": authStateController.email,
+          "profileImageID": uniqueIdForProfileImage,
         },
       );
       await authStateController.account
@@ -103,7 +111,7 @@ class OnboardingController extends GetxController {
 
       // Set user profile in authStateController
       await authStateController.setUserProfileData();
-      customSnackbar("Saved Successfully", "", MessageType.success);
+      customSnackbar("Profile created successfully", "Your user profile is successfully created.", MessageType.success);
       Get.toNamed(AppRoutes.tabview);
     } catch (e) {
       log(e.toString());

--- a/lib/controllers/onboarding_controller.dart
+++ b/lib/controllers/onboarding_controller.dart
@@ -78,7 +78,7 @@ class OnboardingController extends GetxController {
           data: {"email": authStateController.email});
       //Update User Meta Data
       if (profileImagePath != null) {
-        uniqueIdForProfileImage =
+        uniqueIdForProfileImage = authStateController.uid! +
             DateTime.now().millisecondsSinceEpoch.toString();
 
         final profileImage = await storage.createFile(
@@ -111,7 +111,8 @@ class OnboardingController extends GetxController {
 
       // Set user profile in authStateController
       await authStateController.setUserProfileData();
-      customSnackbar("Profile created successfully", "Your user profile is successfully created.", MessageType.success);
+      customSnackbar("Profile created successfully",
+          "Your user profile is successfully created.", MessageType.success);
       Get.toNamed(AppRoutes.tabview);
     } catch (e) {
       log(e.toString());


### PR DESCRIPTION
Fixes #200 

## Description

I added logic to delete the old profile image of the user from storage as the user change or add a new profile image. This way we can maintain the usage of Storage and reduce the redundancy of profile images.

I tried other ways like storing image using user uid or email but it didn't work well so at last,

I created a new attribute in User Docs in the Database to store the UserProfileImageID and used it to delete the Old user image. 
I used DateTime millieSecondsSinceEpoch as a Unique ID for the profile image.

![image](https://github.com/AOSSIE-Org/Resonate/assets/141143426/98b91a8c-60fc-4bf0-ad78-b797769983f2)



## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Everything at the front end and the database works fine. Shared some screenshots and screen-recording to review the changes.

## Screen recordings

https://github.com/AOSSIE-Org/Resonate/assets/141143426/0ba369ed-39f9-49d7-98cf-7a76336e4568



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #200 
- [x] Tag the PR with the appropriate labels

@chandansgowda Please review this.