### PR TITLE
fix: added media query to refresh button to fix right-overflow problem

### DIFF
--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -65,39 +65,45 @@ class HomeScreen extends StatelessWidget {
                                 child: Text(
                                   "No Rooms Available\n Get Started by adding one below!",
                                   textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                      fontSize: UiSizes.size_19),
+                                  style: TextStyle(fontSize: UiSizes.size_19),
                                 ),
                               ),
                               SizedBox(
                                 height: UiSizes.height_10,
                               ),
-                              OutlinedButton(
-                                onPressed: () {
-                                  roomsController.getRooms();
-                                },
-                                style: OutlinedButton.styleFrom(
-                                  maximumSize:
-                                      Size.fromWidth(UiSizes.width_123_4),
-                                  side: const BorderSide(
-                                      color: Colors.amber, width: 1),
-                                ),
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    const Text(
-                                      "Refresh",
-                                      style: TextStyle(color: Colors.amber),
-                                    ),
-                                    SizedBox(
-                                      width: UiSizes.width_6,
-                                    ),
-                                    const Icon(
-                                      Icons.refresh,
-                                      color: Colors.amber,
-                                    ),
-                                  ],
+                              Container(
+                                constraints: BoxConstraints(
+                                    maxWidth:
+                                        MediaQuery.of(context).size.width *
+                                            0.4),
+                                child: OutlinedButton(
+                                  onPressed: () {
+                                    roomsController.getRooms();
+                                  },
+                                  style: OutlinedButton.styleFrom(
+                                    // maximumSize:
+                                    //     Size.fromWidth(UiSizes.width_123_4),
+                                    side: const BorderSide(
+                                        color: Colors.amber, width: 1),
+                                  ),
+                                  child: Row(
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.center,
+                                    children: [
+                                      const Text(
+                                        "Refresh",
+                                        style: TextStyle(color: Colors.amber),
+                                      ),
+                                      SizedBox(
+                                        width: UiSizes.width_6,
+                                      ),
+                                      const Icon(
+                                        Icons.refresh,
+                                        color: Colors.amber,
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               )
                             ],

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -71,39 +71,34 @@ class HomeScreen extends StatelessWidget {
                               SizedBox(
                                 height: UiSizes.height_10,
                               ),
-                              Container(
-                                constraints: BoxConstraints(
-                                    maxWidth:
-                                        MediaQuery.of(context).size.width *
-                                            0.4),
-                                child: OutlinedButton(
-                                  onPressed: () {
-                                    roomsController.getRooms();
-                                  },
-                                  style: OutlinedButton.styleFrom(
-                                    side: const BorderSide(
-                                        color: Colors.amber, width: 1),
-                                  ),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.center,
-                                    children: [
-                                      const Text(
-                                        "Refresh",
-                                        style: TextStyle(color: Colors.amber),
-                                      ),
-                                      SizedBox(
-                                        width: UiSizes.width_6,
-                                      ),
-                                      const Icon(
-                                        Icons.refresh,
-                                        color: Colors.amber,
-                                      ),
-                                    ],
-                                  ),
+                              OutlinedButton(
+                                onPressed: () {
+                                  roomsController.getRooms();
+                                },
+                                style: OutlinedButton.styleFrom(
+                                  maximumSize:
+                                      Size.fromWidth(UiSizes.width_170),
+                                  side: const BorderSide(
+                                      color: Colors.amber, width: 1),
                                 ),
-                              )
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    const Text(
+                                      "Refresh",
+                                      style: TextStyle(color: Colors.amber),
+                                    ),
+                                    SizedBox(
+                                      width: UiSizes.width_6,
+                                    ),
+                                    const Icon(
+                                      Icons.refresh,
+                                      color: Colors.amber,
+                                    ),
+                                  ],
+                                ),
+                              ),
                             ],
                           ),
                         ),

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -81,8 +81,6 @@ class HomeScreen extends StatelessWidget {
                                     roomsController.getRooms();
                                   },
                                   style: OutlinedButton.styleFrom(
-                                    // maximumSize:
-                                    //     Size.fromWidth(UiSizes.width_123_4),
                                     side: const BorderSide(
                                         color: Colors.amber, width: 1),
                                   ),


### PR DESCRIPTION
## Description
Added media query and remove maxWidth Property on the refresh button to fix the right-overflow error getting displayed on home screen.

Fixes #209 

## Type of change

Please delete options that are not relevant.
- [ ✔️ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested by running on my android device.

Please include screenshots below if applicable :

![aossie-issue-ss](https://github.com/AOSSIE-Org/Resonate/assets/92221517/519b32b7-2187-4ca6-987b-967af0f72d64)

## Checklist:

- [ ✔️ ] My code follows the style guidelines of this project
- [✔️ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ✔️ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ✔️ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels