### PR TITLE
feat: Removed delete button for default profile picture

### DIFF
--- a/lib/views/screens/edit_profile_screen.dart
+++ b/lib/views/screens/edit_profile_screen.dart
@@ -301,21 +301,23 @@ class EditProfileScreen extends StatelessWidget {
                 const Text('Gallery')
               ],
             ),
-            Column(
-              children: [
-                IconButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                    editProfileController.removeProfilePicture();
-                  },
-                  icon: const Icon(
-                    Icons.delete,
+            if (authStateController.profileImageUrl !=
+              userProfileImagePlaceholderUrl)
+              Column(
+                children: [
+                  IconButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                      editProfileController.removeProfilePicture();
+                    },
+                    icon: const Icon(
+                      Icons.delete,
+                    ),
+                    iconSize: UiSizes.size_56,
                   ),
-                  iconSize: UiSizes.size_56,
-                ),
-                const Text('Remove')
-              ],
-            ),
+                  const Text('Remove')
+                ],
+              ),
           ],
         ),
       ],


### PR DESCRIPTION
Sure, based on the information you've provided, here's a possible pull request template:

---

## Description

Fixes #215 

This pull request addresses the issue by removing the delete button in the "Edit Profile" section when the profile picture is set to the default. This change aims to enhance user experience and prevent confusion.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves existing functionality)

## How Has This Been Tested?

I have tested this change by:

1. Navigating to the "Edit Profile" section.
2. Verifying that the delete button is hidden when the profile picture is set to the default.
3. Confirming that the delete button is still visible when a custom profile picture is set.

Screenshots:
## Before:
<img src="https://github.com/AOSSIE-Org/Resonate/assets/102402625/4c4dee80-b674-4b6d-beb6-0daadc7fff76" width="400">

## After:
<img src="https://github.com/AOSSIE-Org/Resonate/assets/102402625/33383c5d-4404-4cc4-9f9c-8603b5338ebf" width="400">
<img src="https://github.com/AOSSIE-Org/Resonate/assets/102402625/ee2872b3-b35f-4895-afad-e5eee323f920" width="400">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] Closes #215 