### PR TITLE
Username error text

### DIFF
--- a/lib/views/screens/edit_profile_screen.dart
+++ b/lib/views/screens/edit_profile_screen.dart
@@ -149,7 +149,11 @@ class EditProfileScreen extends StatelessWidget {
                                     Icons.verified_outlined,
                                     color: Colors.green,
                                   )
-                                : null),
+                                : null,
+                            errorStyle: TextStyle(
+                               fontSize: 10,
+                            ),
+                         ),
                       ),
                     ),
                     verticalGap(UiSizes.height_60),


### PR DESCRIPTION
## Description

Previously, the error text when username had less than 5 characters used to overflow and was not entirely visible.

Fixes #234 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

![usernametextsoln](https://github.com/AOSSIE-Org/Resonate/assets/114871036/d36179cd-b5ad-4e52-b52f-140def401da9)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels