### PR TITLE
Fixed Username Error Text

### DIFF
--- a/lib/views/screens/edit_profile_screen.dart
+++ b/lib/views/screens/edit_profile_screen.dart
@@ -150,7 +150,7 @@ class EditProfileScreen extends StatelessWidget {
                                     color: Colors.green,
                                   )
                                 : null,
-                            errorStyle: TextStyle(
+                            errorStyle: const TextStyle(
                                fontSize: 10,
                             ),
                          ),

--- a/lib/views/screens/edit_profile_screen.dart
+++ b/lib/views/screens/edit_profile_screen.dart
@@ -149,7 +149,11 @@ class EditProfileScreen extends StatelessWidget {
                                     Icons.verified_outlined,
                                     color: Colors.green,
                                   )
-                                : null),
+                                : null,
+                            errorStyle: TextStyle(
+                               fontSize: 10,
+                            ),
+                         ),
                       ),
                     ),
                     verticalGap(UiSizes.height_60),


### PR DESCRIPTION
## Description
Previously, the error text when username had less than 5 characters used to overflow and was not entirely visible.

Fixes #234

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
![usernametextsoln](https://github.com/AOSSIE-Org/Resonate/assets/114871036/191a4144-9209-4fe3-809d-d899877192de)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels