### PR TITLE
fix: prevent email auth failure due to trialing spaces

### DIFF
--- a/lib/controllers/authentication_controller.dart
+++ b/lib/controllers/authentication_controller.dart
@@ -26,11 +26,12 @@ class AuthenticationController extends GetxController {
     try {
       isLoading.value = true;
       await authStateController.login(
-          emailController.text, passwordController.text);
+          emailController.text.trim(), passwordController.text);
     } on AppwriteException catch (e) {
       log(e.toString());
       if (e.type == 'user_invalid_credentials') {
-        customSnackbar('Try Again!', "Incorrect Email Or Password", MessageType.error);
+        customSnackbar(
+            'Try Again!', "Incorrect Email Or Password", MessageType.error);
       }
     } catch (e) {
       log(e.toString());
@@ -43,7 +44,7 @@ class AuthenticationController extends GetxController {
     try {
       isLoading.value = true;
       await authStateController.signup(
-          emailController.text, passwordController.text);
+          emailController.text.trim(), passwordController.text);
       return true;
     } catch (e) {
       var error = e.toString().split(": ")[1];
@@ -76,9 +77,10 @@ class AuthenticationController extends GetxController {
 
 extension Validator on String {
   bool isValidEmail() {
-    return RegExp(
-            r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$')
-        .hasMatch(this);
+    // Updated regex to allow trailing spaces
+    final emailRegex = RegExp(
+        r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))\s*$');
+    return emailRegex.hasMatch(this);
   }
 
   bool isValidPassword() {


### PR DESCRIPTION
## Description

 Fixes an issue where email authentication failed due to trailing spaces in email addresses. The changes ensure that trailing spaces are handled correctly during authentication.

Fixes #262 

## Type of change
- Implemented a trimming mechanism to remove trailing spaces from the email input before validation.
- Updated relevant validation functions to account for trimmed email inputs.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?

Conducted manual testing to verify that email inputs with trailing spaces no longer trigger errors.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels