### PR TITLE
[onboarding] trailing space username auth bug fix

### DIFF
--- a/lib/views/screens/onboarding_screen.dart
+++ b/lib/views/screens/onboarding_screen.dart
@@ -105,7 +105,8 @@ class OnBoardingScreen extends StatelessWidget {
                             onChanged: (value) async {
                               if (value.length > 5) {
                                 controller.usernameAvailable.value =
-                                    await controller.isUsernameAvailable(value);
+                                    await controller
+                                        .isUsernameAvailable(value.trim());
                               } else {
                                 controller.usernameAvailable.value = false;
                               }


### PR DESCRIPTION


## Description
The username field on the onboarding_screen was giving error `general_argument_invalid, Invalid documentId param: UID must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can't start with a leading underscore (400)`
This was happening due to a trailing space in the input which was not accounted for.

Fixes #268 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
The code has been tested on my local machine using an android emulator and now the code is functioning as intended.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels