### PR TITLE
[WillPopScope] replace deprecated WillPopScope

### DIFF
--- a/lib/views/screens/create_room_screen.dart
+++ b/lib/views/screens/create_room_screen.dart
@@ -32,10 +32,10 @@ class CreateRoomScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (bool didPop) {
         tabViewController.setIndex(0);
-        return false;
       },
       child: GetBuilder<CreateRoomController>(
         builder: (controller) => Obx(

--- a/lib/views/screens/discussions_screen.dart
+++ b/lib/views/screens/discussions_screen.dart
@@ -19,10 +19,10 @@ class DiscussionScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (bool didPop) {
         tabViewController.setIndex(0);
-        return false;
       },
       child: GetBuilder<DiscussionsController>(
           builder: (discussionsController) => (!discussionsController

--- a/lib/views/screens/edit_profile_screen.dart
+++ b/lib/views/screens/edit_profile_screen.dart
@@ -43,15 +43,12 @@ class EditProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        if (editProfileController.isLoading.value) {
-          return false;
-        } else {
-          if (editProfileController.isThereUnsavedChanges()) {
-            saveChangesDialogue();
-          }
-          return true;
+    return PopScope(
+      canPop: !editProfileController.isLoading.value &&
+          !editProfileController.isThereUnsavedChanges(),
+      onPopInvoked: (bool didPop) {
+        if (didPop && editProfileController.isThereUnsavedChanges()) {
+          saveChangesDialogue();
         }
       },
       child: Scaffold(
@@ -139,21 +136,21 @@ class EditProfileScreen extends StatelessWidget {
                         keyboardType: TextInputType.text,
                         autocorrect: false,
                         decoration: inputDecoration.copyWith(
-                            prefixIcon: const Icon(
-                              Icons.account_circle,
-                            ),
-                            labelText: "Username",
-                            prefixText: "@",
-                            suffixIcon: controller.usernameAvailable.value
-                                ? const Icon(
-                                    Icons.verified_outlined,
-                                    color: Colors.green,
-                                  )
-                                : null,
-                            errorStyle: const TextStyle(
-                               fontSize: 10,
-                            ),
-                         ),
+                          prefixIcon: const Icon(
+                            Icons.account_circle,
+                          ),
+                          labelText: "Username",
+                          prefixText: "@",
+                          suffixIcon: controller.usernameAvailable.value
+                              ? const Icon(
+                                  Icons.verified_outlined,
+                                  color: Colors.green,
+                                )
+                              : null,
+                          errorStyle: const TextStyle(
+                            fontSize: 10,
+                          ),
+                        ),
                       ),
                     ),
                     verticalGap(UiSizes.height_60),
@@ -306,7 +303,7 @@ class EditProfileScreen extends StatelessWidget {
               ],
             ),
             if (authStateController.profileImageUrl !=
-              userProfileImagePlaceholderUrl)
+                userProfileImagePlaceholderUrl)
               Column(
                 children: [
                   IconButton(

--- a/lib/views/screens/pair_chat_screen.dart
+++ b/lib/views/screens/pair_chat_screen.dart
@@ -17,215 +17,215 @@ class PairChatScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     Brightness currentBrightness = Theme.of(context).brightness;
 
-    return WillPopScope(
-        child: Scaffold(
-          appBar: AppBar(
-            toolbarHeight: (UiSizes.size_56),
-            automaticallyImplyLeading: false,
-            title: Text(
-              "Resonate",
-              style: TextStyle(
-                fontSize: UiSizes.size_26,
-              ),
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        appBar: AppBar(
+          toolbarHeight: (UiSizes.size_56),
+          automaticallyImplyLeading: false,
+          title: Text(
+            "Resonate",
+            style: TextStyle(
+              fontSize: UiSizes.size_26,
             ),
-            centerTitle: true,
           ),
-          body: Column(
-            children: [
-              SafeArea(
-                child: Padding(
-                  padding: EdgeInsets.symmetric(
-                      vertical: UiSizes.height_10,
-                      horizontal: UiSizes.width_20),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      //Image.asset("assets/images/resonate_logo.png", height: Get.height*0.2,),
-                      const Text(
-                        "Be polite and respect the other person's opinion. Avoid rude comments.",
-                        style: TextStyle(color: Colors.amber),
-                        textAlign: TextAlign.center,
-                      ),
-                      SizedBox(
-                        height: UiSizes.height_24_6,
-                      ),
-                      Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          // Row 1
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              CircleAvatar(
-                                backgroundImage: NetworkImage(
-                                    controller.isAnonymous.value
-                                        ? userProfileImagePlaceholderUrl
-                                        : authStateController.profileImageUrl!),
-                                radius: UiSizes.width_66,
-                              ),
-                              SizedBox(
-                                width: UiSizes.width_16,
-                              ),
-                              Container(
-                                alignment: Alignment.center,
-                                width: UiSizes.width_100,
-                                child: Text(
+          centerTitle: true,
+        ),
+        body: Column(
+          children: [
+            SafeArea(
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                    vertical: UiSizes.height_10, horizontal: UiSizes.width_20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    //Image.asset("assets/images/resonate_logo.png", height: Get.height*0.2,),
+                    const Text(
+                      "Be polite and respect the other person's opinion. Avoid rude comments.",
+                      style: TextStyle(color: Colors.amber),
+                      textAlign: TextAlign.center,
+                    ),
+                    SizedBox(
+                      height: UiSizes.height_24_6,
+                    ),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        // Row 1
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            CircleAvatar(
+                              backgroundImage: NetworkImage(
                                   controller.isAnonymous.value
-                                      ? "User1"
-                                      : authStateController.userName!,
-                                  style: TextStyle(fontSize: UiSizes.size_16),
-                                  overflow: TextOverflow.ellipsis,
-                                ),
+                                      ? userProfileImagePlaceholderUrl
+                                      : authStateController.profileImageUrl!),
+                              radius: UiSizes.width_66,
+                            ),
+                            SizedBox(
+                              width: UiSizes.width_16,
+                            ),
+                            Container(
+                              alignment: Alignment.center,
+                              width: UiSizes.width_100,
+                              child: Text(
+                                controller.isAnonymous.value
+                                    ? "User1"
+                                    : authStateController.userName!,
+                                style: TextStyle(fontSize: UiSizes.size_16),
+                                overflow: TextOverflow.ellipsis,
                               ),
-                            ],
-                          ),
-                          SizedBox(
-                            height: UiSizes.height_20,
-                          ),
-                          // Row 2
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              CircleAvatar(
-                                backgroundImage: NetworkImage(
-                                    controller.isAnonymous.value
-                                        ? userProfileImagePlaceholderUrl
-                                        : controller.pairProfileImageUrl!),
-                                radius: UiSizes.width_66,
-                              ),
-                              SizedBox(
-                                width: UiSizes.width_16,
-                              ),
-                              Container(
-                                alignment: Alignment.center,
-                                width: UiSizes.width_100,
-                                child: Text(
+                            ),
+                          ],
+                        ),
+                        SizedBox(
+                          height: UiSizes.height_20,
+                        ),
+                        // Row 2
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            CircleAvatar(
+                              backgroundImage: NetworkImage(
                                   controller.isAnonymous.value
-                                      ? "User2"
-                                      : controller.pairUsername!,
-                                  style: TextStyle(fontSize: UiSizes.size_16),
-                                  overflow: TextOverflow.ellipsis,
-                                ),
+                                      ? userProfileImagePlaceholderUrl
+                                      : controller.pairProfileImageUrl!),
+                              radius: UiSizes.width_66,
+                            ),
+                            SizedBox(
+                              width: UiSizes.width_16,
+                            ),
+                            Container(
+                              alignment: Alignment.center,
+                              width: UiSizes.width_100,
+                              child: Text(
+                                controller.isAnonymous.value
+                                    ? "User2"
+                                    : controller.pairUsername!,
+                                style: TextStyle(fontSize: UiSizes.size_16),
+                                overflow: TextOverflow.ellipsis,
                               ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      SizedBox(
-                        height: UiSizes.height_24_6,
-                      ),
-                    ],
-                  ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    SizedBox(
+                      height: UiSizes.height_24_6,
+                    ),
+                  ],
                 ),
               ),
-              const Spacer(),
-              Container(
-                padding: EdgeInsets.symmetric(vertical: UiSizes.height_20),
-                color: currentBrightness == Brightness.light
-                    ? Colors.amber[100]
-                    : Colors.black,
-                height: UiSizes.height_131,
-                child: Obx(() {
-                  return Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Column(
-                        children: [
-                          SizedBox(
-                            height: UiSizes.height_56,
-                            width: UiSizes.width_56,
-                            child: FloatingActionButton(
-                              elevation: 0,
-                              heroTag: "mic",
-                              onPressed: () {
-                                controller.toggleMic();
-                              },
-                              backgroundColor: controller.isMicOn.value
-                                  ? currentBrightness == Brightness.light
-                                      ? Colors.white
-                                      : Colors.white54
-                                  : Colors.amber,
-                              child: Icon(
-                                Icons.mic_off,
-                                size: UiSizes.size_24,
-                              ),
+            ),
+            const Spacer(),
+            Container(
+              padding: EdgeInsets.symmetric(vertical: UiSizes.height_20),
+              color: currentBrightness == Brightness.light
+                  ? Colors.amber[100]
+                  : Colors.black,
+              height: UiSizes.height_131,
+              child: Obx(() {
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    Column(
+                      children: [
+                        SizedBox(
+                          height: UiSizes.height_56,
+                          width: UiSizes.width_56,
+                          child: FloatingActionButton(
+                            elevation: 0,
+                            heroTag: "mic",
+                            onPressed: () {
+                              controller.toggleMic();
+                            },
+                            backgroundColor: controller.isMicOn.value
+                                ? currentBrightness == Brightness.light
+                                    ? Colors.white
+                                    : Colors.white54
+                                : Colors.amber,
+                            child: Icon(
+                              Icons.mic_off,
+                              size: UiSizes.size_24,
                             ),
                           ),
-                          SizedBox(
-                            height: UiSizes.height_4,
-                          ),
-                          Text(
-                            'Mute',
-                            style: TextStyle(fontSize: UiSizes.height_14),
-                          )
-                        ],
-                      ),
-                      Column(
-                        children: [
-                          SizedBox(
-                            height: UiSizes.height_56,
-                            width: UiSizes.width_56,
-                            child: FloatingActionButton(
-                              elevation: 0,
-                              heroTag: "speaker",
-                              onPressed: () {
-                                controller.toggleLoudSpeaker();
-                              },
-                              backgroundColor: controller.isLoudSpeakerOn.value
-                                  ? Colors.amber
-                                  : currentBrightness == Brightness.light
-                                      ? Colors.white
-                                      : Colors.white54,
-                              child: Icon(
-                                Icons.volume_up,
-                                size: UiSizes.size_24,
-                              ),
+                        ),
+                        SizedBox(
+                          height: UiSizes.height_4,
+                        ),
+                        Text(
+                          'Mute',
+                          style: TextStyle(fontSize: UiSizes.height_14),
+                        )
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        SizedBox(
+                          height: UiSizes.height_56,
+                          width: UiSizes.width_56,
+                          child: FloatingActionButton(
+                            elevation: 0,
+                            heroTag: "speaker",
+                            onPressed: () {
+                              controller.toggleLoudSpeaker();
+                            },
+                            backgroundColor: controller.isLoudSpeakerOn.value
+                                ? Colors.amber
+                                : currentBrightness == Brightness.light
+                                    ? Colors.white
+                                    : Colors.white54,
+                            child: Icon(
+                              Icons.volume_up,
+                              size: UiSizes.size_24,
                             ),
                           ),
-                          SizedBox(
-                            height: UiSizes.height_4,
-                          ),
-                          Text(
-                            'Speaker',
-                            style: TextStyle(fontSize: UiSizes.height_14),
-                          )
-                        ],
-                      ),
-                      Column(
-                        children: [
-                          SizedBox(
-                            height: UiSizes.height_56,
-                            width: UiSizes.width_56,
-                            child: FloatingActionButton(
-                              elevation: 0,
-                              heroTag: "end-chat",
-                              onPressed: () async {
-                                await controller.endChat();
-                              },
-                              backgroundColor: Colors.redAccent,
-                              child: Icon(
-                                Icons.cancel_outlined,
-                                size: UiSizes.size_24,
-                              ),
+                        ),
+                        SizedBox(
+                          height: UiSizes.height_4,
+                        ),
+                        Text(
+                          'Speaker',
+                          style: TextStyle(fontSize: UiSizes.height_14),
+                        )
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        SizedBox(
+                          height: UiSizes.height_56,
+                          width: UiSizes.width_56,
+                          child: FloatingActionButton(
+                            elevation: 0,
+                            heroTag: "end-chat",
+                            onPressed: () async {
+                              await controller.endChat();
+                            },
+                            backgroundColor: Colors.redAccent,
+                            child: Icon(
+                              Icons.cancel_outlined,
+                              size: UiSizes.size_24,
                             ),
                           ),
-                          SizedBox(
-                            height: UiSizes.height_4,
-                          ),
-                          Text(
-                            "End",
-                            style: TextStyle(fontSize: UiSizes.height_14),
-                          )
-                        ],
-                      ),
-                    ],
-                  );
-                }),
-              )
-            ],
-          ),
+                        ),
+                        SizedBox(
+                          height: UiSizes.height_4,
+                        ),
+                        Text(
+                          "End",
+                          style: TextStyle(fontSize: UiSizes.height_14),
+                        )
+                      ],
+                    ),
+                  ],
+                );
+              }),
+            )
+          ],
         ),
-        onWillPop: () async => false);
+      ),
+    );
   }
 }

--- a/lib/views/widgets/no_connection_dialog.dart
+++ b/lib/views/widgets/no_connection_dialog.dart
@@ -10,51 +10,51 @@ class NoConnectionDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-        child: Scaffold(
-          body: Center(
-            child: SingleChildScrollView(
-              child: Container(
-                padding: EdgeInsets.symmetric(
-                    vertical: UiSizes.height_24_6,
-                    horizontal: UiSizes.width_25),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    SvgPicture.asset(
-                      AppImages.noConnectionImage,
-                      height: UiSizes.height_246,
-                    ),
-                    Text(
-                      "No Connection",
-                      style: TextStyle(
-                          fontSize: UiSizes.size_40,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.amber),
-                    ),
-                    Text(
-                      "There is a connection error. Please check your internet and try again.",
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: UiSizes.size_16),
-                    ),
-                    SizedBox(
-                      height: UiSizes.height_82,
-                    ),
-                    ElevatedButton(
-                        onPressed: () {
-                          Get.find<NetworkController>().tryAgain();
-                        },
-                        child: Text(
-                          "Try Again",
-                          style: TextStyle(
-                              color: Colors.black, fontSize: UiSizes.size_14),
-                        ))
-                  ],
-                ),
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        body: Center(
+          child: SingleChildScrollView(
+            child: Container(
+              padding: EdgeInsets.symmetric(
+                  vertical: UiSizes.height_24_6, horizontal: UiSizes.width_25),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  SvgPicture.asset(
+                    AppImages.noConnectionImage,
+                    height: UiSizes.height_246,
+                  ),
+                  Text(
+                    "No Connection",
+                    style: TextStyle(
+                        fontSize: UiSizes.size_40,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.amber),
+                  ),
+                  Text(
+                    "There is a connection error. Please check your internet and try again.",
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: UiSizes.size_16),
+                  ),
+                  SizedBox(
+                    height: UiSizes.height_82,
+                  ),
+                  ElevatedButton(
+                      onPressed: () {
+                        Get.find<NetworkController>().tryAgain();
+                      },
+                      child: Text(
+                        "Try Again",
+                        style: TextStyle(
+                            color: Colors.black, fontSize: UiSizes.size_14),
+                      ))
+                ],
               ),
             ),
           ),
         ),
-        onWillPop: () async => false);
+      ),
+    );
   }
 }


### PR DESCRIPTION

## Description

The Flutter framework has deprecated the usage of WillPopScope constructor in favor of PopScope starting from version v3.12.0-1.0.pre. However, there were still instances of WillPopScope being used in the codebase of the project.

Fixes #270 

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

There was no alteration in the functionality of the app before or after transitioning from WillPopScope to PopScope.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels