### PR TITLE
[BugFix] Fix for Null Check Operator Used on a Null Value Exception in UiSizes Class

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,16 @@
+//Explaination:
+//move plugins block at the top
+//define th plugins block using Plugin DSL syntax to migrate to declarative plugin method from imperative
+
+plugins {
+    id "com.android.application"
+    // START: FlutterFire Configuration
+    id "com.google.gms.google-services"
+    // END: FlutterFire Configuration
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -5,11 +18,13 @@ if (localPropertiesFile.exists()) {
         localProperties.load(reader)
     }
 }
+//Explaination:
+//remove this block of code as it is not needed any more in declarative plugin method
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
+/*def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
     throw GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
+}*/
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
@@ -21,16 +36,16 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
+/*apply plugin: 'com.android.application'
 // START: FlutterFire Configuration
 apply plugin: 'com.google.gms.google-services'
 // END: FlutterFire Configuration
 apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"*/
 
 android {
     namespace "com.resonate.resonate"
-    compileSdkVersion 34
+    compileSdkVersion 34 //change from 33 to 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -74,7 +89,7 @@ flutter {
 }
 
 dependencies {
-     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0"
      coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
      implementation 'androidx.window:window:1.0.0'
      implementation 'androidx.window:window-java:1.0.0'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     namespace "com.resonate.resonate"
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,11 @@
-buildscript {
+//Explaination:
+//buildscript is not needed anymore in gradle's declarative plugin method
+//the dependencies are moved to plugins block of android\settings.gradle
+//kotlin_version: '1.8.0' and (android gradle plugin version)agpVersion:'7.1.2' are taken from here
+//also the version: 4.3.10 of 'com.google.gms:google-services' required for Firebase
+//are used in plugins block of android\settings.gradle
+
+/*buildscript {
     ext.kotlin_version = '1.8.0'
     repositories {
         google()
@@ -12,7 +19,7 @@ buildscript {
         // END: FlutterFire Configuration
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-}
+}*/
 
 allprojects {
     repositories {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,3 +1,8 @@
+//Explaination:
+//The piece of code in between /*code*/ is not needed anymore.
+//This code was used in gradle's imperative plugin declaration.
+
+/*
 include ':app'
 
 def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
@@ -9,3 +14,36 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+*/
+
+//Explaination:
+//The new piece of code required for implementing gradles declarative plugin declaration
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+//Explaination:
+//the plugins block which specifies plugins used by the app uses Plugin DSL syntax
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.1.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.0" apply false //{agpVersion} and {kotlinVersion} were taken from android/build.gradle
+    // START: FlutterFire Configuration
+    id "com.google.gms.google-services" version "4.3.10" apply false //version: 4.3.10 of 'com.google.gms:google-services' is taken from old buildscript block from android/build.gradle
+    // END: FlutterFire Configuration
+}
+
+include ":app"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:resonate/routes/app_pages.dart';
 import 'package:resonate/routes/app_routes.dart';
 import 'package:resonate/themes/themes.dart';
 import 'package:get_storage/get_storage.dart';
+import 'package:resonate/utils/ui_sizes.dart';
 import 'package:resonate/views/screens/discussions_screen.dart';
 import 'themes/theme_controller.dart';
 
@@ -30,6 +31,8 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    UiSizes.init(context);
+
     final themeController = Get.put(ThemeController());
     return GetMaterialApp(
       debugShowCheckedModeBanner: false,

--- a/lib/utils/ui_sizes.dart
+++ b/lib/utils/ui_sizes.dart
@@ -1,111 +1,245 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class UiSizes {
   // Height expressions
-  static double height_1 = Get.height * 0.0012;
-  static double height_2 = Get.height * 0.0024;
-  static double height_4 = Get.height * 0.005;
-  static double height_5 = Get.height * 0.006;
-  static double height_7 = Get.height * 0.0085;
-  static double height_8 = Get.height * 0.0097;
-  static double height_10 = Get.height * 0.012;
-  static double height_12 = Get.height * 0.015;
-  static double height_14 = Get.height * 0.017;
-  static double height_15 = Get.height * 0.018;
-  static double height_16 = Get.height * 0.0206888;
-  static double height_20 = Get.height * 0.024;
-  static double height_24_6 = Get.height * 0.03;
-  static double height_26 = Get.height * 0.0316;
-  static double height_30 = Get.height * 0.036;
-  static double height_33 = Get.height * 0.04;
-  static double height_35 = Get.height * 0.0425;
-  static double height_40 = Get.height * 0.045;
-  static double height_45 = Get.height * 0.05476;
-  static double height_55 = Get.height * 0.067;
-  static double height_56 = Get.height * 0.06815;
-  static double height_60 = Get.height * 0.073;
-  static double height_66 = Get.height * 0.08;
-  static double height_70 = Get.height * 0.085;
-  static double height_76 = Get.height * 0.0921;
-  static double height_80 = Get.height * 0.0973;
-  static double height_82 = Get.height * 0.1;
-  static double height_90 = Get.height * 0.1095;
-  static double height_110 = Get.height * 0.133;
-  static double height_131 = Get.height * 0.16;
-  static double height_140 = Get.height * 0.17;
-  static double height_160 = Get.height * 0.1945;
-  static double height_170 = Get.height * 0.2;
-  static double height_180 = Get.height * 0.219;
-  static double height_200 = Get.height * 0.243;
-  static double height_246 = Get.height * 0.3;
-  static double height_600 = Get.height * 0.73;
-  static double height_660 = Get.height * 0.8;
-  static double height_700 = Get.height * 0.85;
-  static double height_710 = Get.height * 0.864;
-  static double height_740 = Get.height * 0.9;
-  static double height_756 = Get.height * 0.92;
-  static double height_765 = Get.height * 0.93;
-  static double height_780 = Get.height * 0.95;
+  static late double height_1;
+  static late double height_2;
+  static late double height_4;
+  static late double height_5;
+  static late double height_7;
+  static late double height_8;
+  static late double height_10;
+  static late double height_12;
+  static late double height_14;
+  static late double height_15;
+  static late double height_16;
+  static late double height_20;
+  static late double height_24_6;
+  static late double height_26;
+  static late double height_30;
+  static late double height_33;
+  static late double height_35;
+  static late double height_40;
+  static late double height_45;
+  static late double height_55;
+  static late double height_56;
+  static late double height_60;
+  static late double height_66;
+  static late double height_70;
+  static late double height_76;
+  static late double height_80;
+  static late double height_82;
+  static late double height_90;
+  static late double height_110;
+  static late double height_131;
+  static late double height_140;
+  static late double height_160;
+  static late double height_170;
+  static late double height_180;
+  static late double height_200;
+  static late double height_246;
+  static late double height_600;
+  static late double height_660;
+  static late double height_700;
+  static late double height_710;
+  static late double height_740;
+  static late double height_756;
+  static late double height_765;
+  static late double height_780;
 
   // Width expressions
-  static double width_1 = 0.0024 * Get.width;
-  static double width_1_5 = 0.00364 * Get.width;
-  static double width_2 = 0.00486 * Get.width;
-  static double width_3 = 0.0072 * Get.width;
-  static double width_4 = 0.009 * Get.width;
-  static double width_5 = 0.012 * Get.width;
-  static double width_6 = 0.015 * Get.width;
-  static double width_8 = 0.02 * Get.width;
-  static double width_10 = 0.024 * Get.width;
-  static double width_16 = 0.04 * Get.width;
-  static double width_20 = 0.0486 * Get.width;
-  static double width_25 = 0.0608 * Get.width;
-  static double width_30 = 0.072 * Get.width;
-  static double width_33 = 0.08 * Get.width;
-  static double width_35 = 0.085 * Get.width;
-  static double width_40 = 0.0972 * Get.width;
-  static double width_45 = 0.109 * Get.width;
-  static double width_56 = 0.1361 * Get.width;
-  static double width_66 = 0.16 * Get.width;
-  static double width_80 = 0.1944 * Get.width;
-  static double width_100 = 0.243 * Get.width;
-  static double width_111 = 0.27 * Get.width;
-  static double width_123_4 = 0.30 * Get.width;
-  static double width_140 = 0.34 * Get.width;
-  static double width_160 = 0.3889 * Get.width;
-  static double width_170 = 0.413 * Get.width;
-  static double width_180 = 0.437 * Get.width;
-  static double width_190 = 0.461 * Get.width;
-  static double width_200 = 0.486 * Get.width;
-  static double width_294 = 0.7146 * Get.width;
-  static double width_300 = 0.729 * Get.width;
-  static double width_304 = 0.74 * Get.width;
-  static double width_320 = 0.77783 * Get.width;
+  static late double width_1;
+  static late double width_1_5;
+  static late double width_2;
+  static late double width_3;
+  static late double width_4;
+  static late double width_5;
+  static late double width_6;
+  static late double width_8;
+  static late double width_10;
+  static late double width_16;
+  static late double width_20;
+  static late double width_25;
+  static late double width_30;
+  static late double width_33;
+  static late double width_35;
+  static late double width_40;
+  static late double width_45;
+  static late double width_56;
+  static late double width_66;
+  static late double width_80;
+  static late double width_100;
+  static late double width_111;
+  static late double width_123_4;
+  static late double width_140;
+  static late double width_160;
+  static late double width_170;
+  static late double width_180;
+  static late double width_190;
+  static late double width_200;
+  static late double width_294;
+  static late double width_300;
+  static late double width_304;
+  static late double width_320;
 
   // Size expressions
-  static double size_8 = 0.009722 * Get.width + 0.00486 * Get.height;
-  static double size_12 = 0.0073 * Get.height + 0.01458 * Get.width;
-  static double size_13 = 0.008 * Get.height + 0.015 * Get.width;
-  static double size_14 = 0.0085 * Get.height + 0.017 * Get.width;
-  static double size_15 = 0.0182 * Get.width + 0.009127 * Get.height;
-  static double size_16 = 0.02187 * Get.width + 0.01095 * Get.height;
-  static double size_17 = 0.01 * Get.height + 0.021 * Get.width;
-  static double size_18 = 0.0109 * Get.height + 0.0218 * Get.width;
-  static double size_19 = 0.024 * Get.width + 0.012 * Get.height;
-  static double size_20 = 0.012 * Get.height + 0.024 * Get.width;
-  static double size_21_3 = 0.013 * Get.height + 0.026 * Get.width;
-  static double size_23 = 0.014 * Get.height + 0.029 * Get.width;
-  static double size_24 = 0.0146 * Get.height + 0.029 * Get.width;
-  static double size_25 = 0.015 * Get.height + 0.03 * Get.width;
-  static double size_26 = 0.0315 * Get.width + 0.01582 * Get.height;
-  static double size_28 = 0.017 * Get.height + 0.034 * Get.width;
-  static double size_30 = 0.01825 * Get.height + 0.0364 * Get.width;
-  static double size_32 = 0.01947 * Get.height + 0.03889 * Get.width;
-  static double size_35 = 0.021 * Get.height + 0.0425 * Get.width;
-  static double size_40 = 0.024 * Get.height + 0.048 * Get.width;
+  static late double size_8;
+  static late double size_12;
+  static late double size_13;
+  static late double size_14;
+  static late double size_15;
+  static late double size_16;
+  static late double size_17;
+  static late double size_18;
+  static late double size_19;
+  static late double size_20;
+  static late double size_21_3;
+  static late double size_23;
+  static late double size_24;
+  static late double size_25;
+  static late double size_26;
+  static late double size_28;
+  static late double size_30;
+  static late double size_32;
+  static late double size_35;
+  static late double size_40;
+  static late double size_56;
+  static late double size_65;
+  static late double size_70;
+  static late double size_200;
 
-  static double size_56 = 0.068 * Get.width + 0.034 * Get.height;
-  static double size_65 = 0.0395 * Get.height + 0.0789 * Get.width;
-  static double size_70 = 0.0425 * Get.height + 0.085 * Get.width;
-  static double size_200 = 0.1216 * Get.height + 0.243 * Get.width;
+  static void init(BuildContext context) {
+    // Height expressions
+    height_1 = MediaQuery.of(context).size.height * 0.0012;
+    height_2 = MediaQuery.of(context).size.height * 0.0024;
+    height_4 = MediaQuery.of(context).size.height * 0.005;
+    height_5 = MediaQuery.of(context).size.height * 0.006;
+    height_7 = MediaQuery.of(context).size.height * 0.0085;
+    height_8 = MediaQuery.of(context).size.height * 0.0097;
+    height_10 = MediaQuery.of(context).size.height * 0.012;
+    height_12 = MediaQuery.of(context).size.height * 0.015;
+    height_14 = MediaQuery.of(context).size.height * 0.017;
+    height_15 = MediaQuery.of(context).size.height * 0.018;
+    height_16 = MediaQuery.of(context).size.height * 0.0206888;
+    height_20 = MediaQuery.of(context).size.height * 0.024;
+    height_24_6 = MediaQuery.of(context).size.height * 0.03;
+    height_26 = MediaQuery.of(context).size.height * 0.0316;
+    height_30 = MediaQuery.of(context).size.height * 0.036;
+    height_33 = MediaQuery.of(context).size.height * 0.04;
+    height_35 = MediaQuery.of(context).size.height * 0.0425;
+    height_40 = MediaQuery.of(context).size.height * 0.045;
+    height_45 = MediaQuery.of(context).size.height * 0.05476;
+    height_55 = MediaQuery.of(context).size.height * 0.067;
+    height_56 = MediaQuery.of(context).size.height * 0.06815;
+    height_60 = MediaQuery.of(context).size.height * 0.073;
+    height_66 = MediaQuery.of(context).size.height * 0.08;
+    height_70 = MediaQuery.of(context).size.height * 0.085;
+    height_76 = MediaQuery.of(context).size.height * 0.0921;
+    height_80 = MediaQuery.of(context).size.height * 0.0973;
+    height_82 = MediaQuery.of(context).size.height * 0.1;
+    height_90 = MediaQuery.of(context).size.height * 0.1095;
+    height_110 = MediaQuery.of(context).size.height * 0.133;
+    height_131 = MediaQuery.of(context).size.height * 0.16;
+    height_140 = MediaQuery.of(context).size.height * 0.17;
+    height_160 = MediaQuery.of(context).size.height * 0.1945;
+    height_170 = MediaQuery.of(context).size.height * 0.2;
+    height_180 = MediaQuery.of(context).size.height * 0.219;
+    height_200 = MediaQuery.of(context).size.height * 0.243;
+    height_246 = MediaQuery.of(context).size.height * 0.3;
+    height_600 = MediaQuery.of(context).size.height * 0.73;
+    height_660 = MediaQuery.of(context).size.height * 0.8;
+    height_700 = MediaQuery.of(context).size.height * 0.85;
+    height_710 = MediaQuery.of(context).size.height * 0.864;
+    height_740 = MediaQuery.of(context).size.height * 0.9;
+    height_756 = MediaQuery.of(context).size.height * 0.92;
+    height_765 = MediaQuery.of(context).size.height * 0.93;
+    height_780 = MediaQuery.of(context).size.height * 0.95;
+
+    // Width expressions
+    width_1 = 0.0024 * MediaQuery.of(context).size.width;
+    width_1_5 = 0.00364 * MediaQuery.of(context).size.width;
+    width_2 = 0.00486 * MediaQuery.of(context).size.width;
+    width_3 = 0.0072 * MediaQuery.of(context).size.width;
+    width_4 = 0.009 * MediaQuery.of(context).size.width;
+    width_5 = 0.012 * MediaQuery.of(context).size.width;
+    width_6 = 0.015 * MediaQuery.of(context).size.width;
+    width_8 = 0.02 * MediaQuery.of(context).size.width;
+    width_10 = 0.024 * MediaQuery.of(context).size.width;
+    width_16 = 0.04 * MediaQuery.of(context).size.width;
+    width_20 = 0.0486 * MediaQuery.of(context).size.width;
+    width_25 = 0.0608 * MediaQuery.of(context).size.width;
+    width_30 = 0.072 * MediaQuery.of(context).size.width;
+    width_33 = 0.08 * MediaQuery.of(context).size.width;
+    width_35 = 0.085 * MediaQuery.of(context).size.width;
+    width_40 = 0.0972 * MediaQuery.of(context).size.width;
+    width_45 = 0.109 * MediaQuery.of(context).size.width;
+    width_56 = 0.1361 * MediaQuery.of(context).size.width;
+    width_66 = 0.16 * MediaQuery.of(context).size.width;
+    width_80 = 0.1944 * MediaQuery.of(context).size.width;
+    width_100 = 0.243 * MediaQuery.of(context).size.width;
+    width_111 = 0.27 * MediaQuery.of(context).size.width;
+    width_123_4 = 0.30 * MediaQuery.of(context).size.width;
+    width_140 = 0.34 * MediaQuery.of(context).size.width;
+    width_160 = 0.3889 * MediaQuery.of(context).size.width;
+    width_170 = 0.413 * MediaQuery.of(context).size.width;
+    width_180 = 0.437 * MediaQuery.of(context).size.width;
+    width_190 = 0.461 * MediaQuery.of(context).size.width;
+    width_200 = 0.486 * MediaQuery.of(context).size.width;
+    width_294 = 0.7146 * MediaQuery.of(context).size.width;
+    width_300 = 0.729 * MediaQuery.of(context).size.width;
+    width_304 = 0.74 * MediaQuery.of(context).size.width;
+    width_320 = 0.77783 * MediaQuery.of(context).size.width;
+
+    // Size expressions
+    size_8 = 0.009722 * MediaQuery.of(context).size.width +
+        0.00486 * MediaQuery.of(context).size.height;
+    size_12 = 0.0073 * MediaQuery.of(context).size.height +
+        0.01458 * MediaQuery.of(context).size.width;
+    size_13 = 0.008 * MediaQuery.of(context).size.height +
+        0.015 * MediaQuery.of(context).size.width;
+    size_14 = 0.0085 * MediaQuery.of(context).size.height +
+        0.017 * MediaQuery.of(context).size.width;
+    size_15 = 0.0182 * MediaQuery.of(context).size.width +
+        0.009127 * MediaQuery.of(context).size.height;
+    size_16 = 0.02187 * MediaQuery.of(context).size.width +
+        0.01095 * MediaQuery.of(context).size.height;
+    size_17 = 0.01 * MediaQuery.of(context).size.height +
+        0.021 * MediaQuery.of(context).size.width;
+    size_18 = 0.0109 * MediaQuery.of(context).size.height +
+        0.0218 * MediaQuery.of(context).size.width;
+    size_19 = 0.024 * MediaQuery.of(context).size.width +
+        0.012 * MediaQuery.of(context).size.height;
+    size_20 = 0.012 * MediaQuery.of(context).size.height +
+        0.024 * MediaQuery.of(context).size.width;
+    size_21_3 = 0.013 * MediaQuery.of(context).size.height +
+        0.026 * MediaQuery.of(context).size.width;
+    size_23 = 0.014 * MediaQuery.of(context).size.height +
+        0.029 * MediaQuery.of(context).size.width;
+    size_24 = 0.0146 * MediaQuery.of(context).size.height +
+        0.029 * MediaQuery.of(context).size.width;
+    size_25 = 0.015 * MediaQuery.of(context).size.height +
+        0.03 * MediaQuery.of(context).size.width;
+    size_26 = 0.0315 * MediaQuery.of(context).size.width +
+        0.01582 * MediaQuery.of(context).size.height;
+    size_28 = 0.017 * MediaQuery.of(context).size.height +
+        0.034 * MediaQuery.of(context).size.width;
+    size_30 = 0.01825 * MediaQuery.of(context).size.height +
+        0.0364 * MediaQuery.of(context).size.width;
+    size_32 = 0.01947 * MediaQuery.of(context).size.height +
+        0.03889 * MediaQuery.of(context).size.width;
+    size_35 = 0.021 * MediaQuery.of(context).size.height +
+        0.0425 * MediaQuery.of(context).size.width;
+    size_40 = 0.024 * MediaQuery.of(context).size.height +
+        0.048 * MediaQuery.of(context).size.width;
+
+    size_56 = 0.068 * MediaQuery.of(context).size.width +
+        0.034 * MediaQuery.of(context).size.height;
+    size_65 = 0.0395 * MediaQuery.of(context).size.height +
+        0.0789 * MediaQuery.of(context).size.width;
+    size_70 = 0.0425 * MediaQuery.of(context).size.height +
+        0.085 * MediaQuery.of(context).size.width;
+    size_200 = 0.1216 * MediaQuery.of(context).size.height +
+        0.243 * MediaQuery.of(context).size.width;
+  }
 }

--- a/lib/utils/ui_sizes.dart
+++ b/lib/utils/ui_sizes.dart
@@ -110,136 +110,114 @@ class UiSizes {
   static late double size_200;
 
   static void init(BuildContext context) {
+    double screenHight = MediaQuery.of(context).size.height;
+    double screenWidth = MediaQuery.of(context).size.width;
     // Height expressions
-    height_1 = MediaQuery.of(context).size.height * 0.0012;
-    height_2 = MediaQuery.of(context).size.height * 0.0024;
-    height_4 = MediaQuery.of(context).size.height * 0.005;
-    height_5 = MediaQuery.of(context).size.height * 0.006;
-    height_7 = MediaQuery.of(context).size.height * 0.0085;
-    height_8 = MediaQuery.of(context).size.height * 0.0097;
-    height_10 = MediaQuery.of(context).size.height * 0.012;
-    height_12 = MediaQuery.of(context).size.height * 0.015;
-    height_14 = MediaQuery.of(context).size.height * 0.017;
-    height_15 = MediaQuery.of(context).size.height * 0.018;
-    height_16 = MediaQuery.of(context).size.height * 0.0206888;
-    height_20 = MediaQuery.of(context).size.height * 0.024;
-    height_24_6 = MediaQuery.of(context).size.height * 0.03;
-    height_26 = MediaQuery.of(context).size.height * 0.0316;
-    height_30 = MediaQuery.of(context).size.height * 0.036;
-    height_33 = MediaQuery.of(context).size.height * 0.04;
-    height_35 = MediaQuery.of(context).size.height * 0.0425;
-    height_40 = MediaQuery.of(context).size.height * 0.045;
-    height_45 = MediaQuery.of(context).size.height * 0.05476;
-    height_55 = MediaQuery.of(context).size.height * 0.067;
-    height_56 = MediaQuery.of(context).size.height * 0.06815;
-    height_60 = MediaQuery.of(context).size.height * 0.073;
-    height_66 = MediaQuery.of(context).size.height * 0.08;
-    height_70 = MediaQuery.of(context).size.height * 0.085;
-    height_76 = MediaQuery.of(context).size.height * 0.0921;
-    height_80 = MediaQuery.of(context).size.height * 0.0973;
-    height_82 = MediaQuery.of(context).size.height * 0.1;
-    height_90 = MediaQuery.of(context).size.height * 0.1095;
-    height_110 = MediaQuery.of(context).size.height * 0.133;
-    height_131 = MediaQuery.of(context).size.height * 0.16;
-    height_140 = MediaQuery.of(context).size.height * 0.17;
-    height_160 = MediaQuery.of(context).size.height * 0.1945;
-    height_170 = MediaQuery.of(context).size.height * 0.2;
-    height_180 = MediaQuery.of(context).size.height * 0.219;
-    height_200 = MediaQuery.of(context).size.height * 0.243;
-    height_246 = MediaQuery.of(context).size.height * 0.3;
-    height_600 = MediaQuery.of(context).size.height * 0.73;
-    height_660 = MediaQuery.of(context).size.height * 0.8;
-    height_700 = MediaQuery.of(context).size.height * 0.85;
-    height_710 = MediaQuery.of(context).size.height * 0.864;
-    height_740 = MediaQuery.of(context).size.height * 0.9;
-    height_756 = MediaQuery.of(context).size.height * 0.92;
-    height_765 = MediaQuery.of(context).size.height * 0.93;
-    height_780 = MediaQuery.of(context).size.height * 0.95;
+    height_1 = screenHight * 0.0012;
+    height_2 = screenHight * 0.0024;
+    height_4 = screenHight * 0.005;
+    height_5 = screenHight * 0.006;
+    height_7 = screenHight * 0.0085;
+    height_8 = screenHight * 0.0097;
+    height_10 = screenHight * 0.012;
+    height_12 = screenHight * 0.015;
+    height_14 = screenHight * 0.017;
+    height_15 = screenHight * 0.018;
+    height_16 = screenHight * 0.0206888;
+    height_20 = screenHight * 0.024;
+    height_24_6 = screenHight * 0.03;
+    height_26 = screenHight * 0.0316;
+    height_30 = screenHight * 0.036;
+    height_33 = screenHight * 0.04;
+    height_35 = screenHight * 0.0425;
+    height_40 = screenHight * 0.045;
+    height_45 = screenHight * 0.05476;
+    height_55 = screenHight * 0.067;
+    height_56 = screenHight * 0.06815;
+    height_60 = screenHight * 0.073;
+    height_66 = screenHight * 0.08;
+    height_70 = screenHight * 0.085;
+    height_76 = screenHight * 0.0921;
+    height_80 = screenHight * 0.0973;
+    height_82 = screenHight * 0.1;
+    height_90 = screenHight * 0.1095;
+    height_110 = screenHight * 0.133;
+    height_131 = screenHight * 0.16;
+    height_140 = screenHight * 0.17;
+    height_160 = screenHight * 0.1945;
+    height_170 = screenHight * 0.2;
+    height_180 = screenHight * 0.219;
+    height_200 = screenHight * 0.243;
+    height_246 = screenHight * 0.3;
+    height_600 = screenHight * 0.73;
+    height_660 = screenHight * 0.8;
+    height_700 = screenHight * 0.85;
+    height_710 = screenHight * 0.864;
+    height_740 = screenHight * 0.9;
+    height_756 = screenHight * 0.92;
+    height_765 = screenHight * 0.93;
+    height_780 = screenHight * 0.95;
 
     // Width expressions
-    width_1 = 0.0024 * MediaQuery.of(context).size.width;
-    width_1_5 = 0.00364 * MediaQuery.of(context).size.width;
-    width_2 = 0.00486 * MediaQuery.of(context).size.width;
-    width_3 = 0.0072 * MediaQuery.of(context).size.width;
-    width_4 = 0.009 * MediaQuery.of(context).size.width;
-    width_5 = 0.012 * MediaQuery.of(context).size.width;
-    width_6 = 0.015 * MediaQuery.of(context).size.width;
-    width_8 = 0.02 * MediaQuery.of(context).size.width;
-    width_10 = 0.024 * MediaQuery.of(context).size.width;
-    width_16 = 0.04 * MediaQuery.of(context).size.width;
-    width_20 = 0.0486 * MediaQuery.of(context).size.width;
-    width_25 = 0.0608 * MediaQuery.of(context).size.width;
-    width_30 = 0.072 * MediaQuery.of(context).size.width;
-    width_33 = 0.08 * MediaQuery.of(context).size.width;
-    width_35 = 0.085 * MediaQuery.of(context).size.width;
-    width_40 = 0.0972 * MediaQuery.of(context).size.width;
-    width_45 = 0.109 * MediaQuery.of(context).size.width;
-    width_56 = 0.1361 * MediaQuery.of(context).size.width;
-    width_66 = 0.16 * MediaQuery.of(context).size.width;
-    width_80 = 0.1944 * MediaQuery.of(context).size.width;
-    width_100 = 0.243 * MediaQuery.of(context).size.width;
-    width_111 = 0.27 * MediaQuery.of(context).size.width;
-    width_123_4 = 0.30 * MediaQuery.of(context).size.width;
-    width_140 = 0.34 * MediaQuery.of(context).size.width;
-    width_160 = 0.3889 * MediaQuery.of(context).size.width;
-    width_170 = 0.413 * MediaQuery.of(context).size.width;
-    width_180 = 0.437 * MediaQuery.of(context).size.width;
-    width_190 = 0.461 * MediaQuery.of(context).size.width;
-    width_200 = 0.486 * MediaQuery.of(context).size.width;
-    width_294 = 0.7146 * MediaQuery.of(context).size.width;
-    width_300 = 0.729 * MediaQuery.of(context).size.width;
-    width_304 = 0.74 * MediaQuery.of(context).size.width;
-    width_320 = 0.77783 * MediaQuery.of(context).size.width;
+    width_1 = 0.0024 * screenWidth;
+    width_1_5 = 0.00364 * screenWidth;
+    width_2 = 0.00486 * screenWidth;
+    width_3 = 0.0072 * screenWidth;
+    width_4 = 0.009 * screenWidth;
+    width_5 = 0.012 * screenWidth;
+    width_6 = 0.015 * screenWidth;
+    width_8 = 0.02 * screenWidth;
+    width_10 = 0.024 * screenWidth;
+    width_16 = 0.04 * screenWidth;
+    width_20 = 0.0486 * screenWidth;
+    width_25 = 0.0608 * screenWidth;
+    width_30 = 0.072 * screenWidth;
+    width_33 = 0.08 * screenWidth;
+    width_35 = 0.085 * screenWidth;
+    width_40 = 0.0972 * screenWidth;
+    width_45 = 0.109 * screenWidth;
+    width_56 = 0.1361 * screenWidth;
+    width_66 = 0.16 * screenWidth;
+    width_80 = 0.1944 * screenWidth;
+    width_100 = 0.243 * screenWidth;
+    width_111 = 0.27 * screenWidth;
+    width_123_4 = 0.30 * screenWidth;
+    width_140 = 0.34 * screenWidth;
+    width_160 = 0.3889 * screenWidth;
+    width_170 = 0.413 * screenWidth;
+    width_180 = 0.437 * screenWidth;
+    width_190 = 0.461 * screenWidth;
+    width_200 = 0.486 * screenWidth;
+    width_294 = 0.7146 * screenWidth;
+    width_300 = 0.729 * screenWidth;
+    width_304 = 0.74 * screenWidth;
+    width_320 = 0.77783 * screenWidth;
 
     // Size expressions
-    size_8 = 0.009722 * MediaQuery.of(context).size.width +
-        0.00486 * MediaQuery.of(context).size.height;
-    size_12 = 0.0073 * MediaQuery.of(context).size.height +
-        0.01458 * MediaQuery.of(context).size.width;
-    size_13 = 0.008 * MediaQuery.of(context).size.height +
-        0.015 * MediaQuery.of(context).size.width;
-    size_14 = 0.0085 * MediaQuery.of(context).size.height +
-        0.017 * MediaQuery.of(context).size.width;
-    size_15 = 0.0182 * MediaQuery.of(context).size.width +
-        0.009127 * MediaQuery.of(context).size.height;
-    size_16 = 0.02187 * MediaQuery.of(context).size.width +
-        0.01095 * MediaQuery.of(context).size.height;
-    size_17 = 0.01 * MediaQuery.of(context).size.height +
-        0.021 * MediaQuery.of(context).size.width;
-    size_18 = 0.0109 * MediaQuery.of(context).size.height +
-        0.0218 * MediaQuery.of(context).size.width;
-    size_19 = 0.024 * MediaQuery.of(context).size.width +
-        0.012 * MediaQuery.of(context).size.height;
-    size_20 = 0.012 * MediaQuery.of(context).size.height +
-        0.024 * MediaQuery.of(context).size.width;
-    size_21_3 = 0.013 * MediaQuery.of(context).size.height +
-        0.026 * MediaQuery.of(context).size.width;
-    size_23 = 0.014 * MediaQuery.of(context).size.height +
-        0.029 * MediaQuery.of(context).size.width;
-    size_24 = 0.0146 * MediaQuery.of(context).size.height +
-        0.029 * MediaQuery.of(context).size.width;
-    size_25 = 0.015 * MediaQuery.of(context).size.height +
-        0.03 * MediaQuery.of(context).size.width;
-    size_26 = 0.0315 * MediaQuery.of(context).size.width +
-        0.01582 * MediaQuery.of(context).size.height;
-    size_28 = 0.017 * MediaQuery.of(context).size.height +
-        0.034 * MediaQuery.of(context).size.width;
-    size_30 = 0.01825 * MediaQuery.of(context).size.height +
-        0.0364 * MediaQuery.of(context).size.width;
-    size_32 = 0.01947 * MediaQuery.of(context).size.height +
-        0.03889 * MediaQuery.of(context).size.width;
-    size_35 = 0.021 * MediaQuery.of(context).size.height +
-        0.0425 * MediaQuery.of(context).size.width;
-    size_40 = 0.024 * MediaQuery.of(context).size.height +
-        0.048 * MediaQuery.of(context).size.width;
+    size_8 = 0.009722 * screenWidth + 0.00486 * screenHight;
+    size_12 = 0.0073 * screenHight + 0.01458 * screenWidth;
+    size_13 = 0.008 * screenHight + 0.015 * screenWidth;
+    size_14 = 0.0085 * screenHight + 0.017 * screenWidth;
+    size_15 = 0.0182 * screenWidth + 0.009127 * screenHight;
+    size_16 = 0.02187 * screenWidth + 0.01095 * screenHight;
+    size_17 = 0.01 * screenHight + 0.021 * screenWidth;
+    size_18 = 0.0109 * screenHight + 0.0218 * screenWidth;
+    size_19 = 0.024 * screenWidth + 0.012 * screenHight;
+    size_20 = 0.012 * screenHight + 0.024 * screenWidth;
+    size_21_3 = 0.013 * screenHight + 0.026 * screenWidth;
+    size_23 = 0.014 * screenHight + 0.029 * screenWidth;
+    size_24 = 0.0146 * screenHight + 0.029 * screenWidth;
+    size_25 = 0.015 * screenHight + 0.03 * screenWidth;
+    size_26 = 0.0315 * screenWidth + 0.01582 * screenHight;
+    size_28 = 0.017 * screenHight + 0.034 * screenWidth;
+    size_30 = 0.01825 * screenHight + 0.0364 * screenWidth;
+    size_32 = 0.01947 * screenHight + 0.03889 * screenWidth;
+    size_35 = 0.021 * screenHight + 0.0425 * screenWidth;
+    size_40 = 0.024 * screenHight + 0.048 * screenWidth;
 
-    size_56 = 0.068 * MediaQuery.of(context).size.width +
-        0.034 * MediaQuery.of(context).size.height;
-    size_65 = 0.0395 * MediaQuery.of(context).size.height +
-        0.0789 * MediaQuery.of(context).size.width;
-    size_70 = 0.0425 * MediaQuery.of(context).size.height +
-        0.085 * MediaQuery.of(context).size.width;
-    size_200 = 0.1216 * MediaQuery.of(context).size.height +
-        0.243 * MediaQuery.of(context).size.width;
+    size_56 = 0.068 * screenWidth + 0.034 * screenHight;
+    size_65 = 0.0395 * screenHight + 0.0789 * screenWidth;
+    size_70 = 0.0425 * screenHight + 0.085 * screenWidth;
+    size_200 = 0.1216 * screenHight + 0.243 * screenWidth;
   }
 }

--- a/lib/views/screens/create_room_screen.dart
+++ b/lib/views/screens/create_room_screen.dart
@@ -199,19 +199,19 @@ class CreateRoomScreen extends StatelessWidget {
                             height: UiSizes.height_33,
                           ),
                           TextFieldTags(
-                            textfieldTagsController: controller.tagsController,
-                            initialTags: const ['sample-tag'],
-                            textSeparators: const [' ', ','],
-                            letterCase: LetterCase.normal,
-                            validator: (String tag) =>
-                                tag.isValidTag() ? null : "Invalid Tag",
-                            inputfieldBuilder: (context, tec, fn, error,
-                                onChanged, onSubmitted) {
-                              return ((context, sc, tags, onTagDelete) {
+                              textfieldTagsController:
+                                  controller.tagsController,
+                              initialTags: const ['sample-tag'],
+                              textSeparators: const [' ', ','],
+                              letterCase: LetterCase.normal,
+                              validator: (tag) =>
+                                  tag.isValidTag() ? null : "Invalid Tag",
+                              inputFieldBuilder: (context, inputFieldValues) {
                                 return TextField(
                                   style: TextStyle(fontSize: UiSizes.size_20),
-                                  controller: tec,
-                                  focusNode: fn,
+                                  controller:
+                                      inputFieldValues.textEditingController,
+                                  focusNode: inputFieldValues.focusNode,
                                   decoration: InputDecoration(
                                     filled: true,
                                     fillColor: const Color(0x15FFFFFF),
@@ -220,16 +220,17 @@ class CreateRoomScreen extends StatelessWidget {
                                     enabledBorder: kEnabledTextFieldBorder,
                                     focusedBorder: kFocusedTextFieldBorder,
                                     hintText: "Enter tags",
-                                    errorText: error,
+                                    errorText: inputFieldValues.error,
                                     prefixIconConstraints: BoxConstraints(
                                         maxWidth: UiSizes.width_304),
-                                    prefixIcon: tags.isNotEmpty
+                                    prefixIcon: inputFieldValues.tags.isNotEmpty
                                         ? SingleChildScrollView(
-                                            controller: sc,
+                                            controller: inputFieldValues
+                                                .tagScrollController,
                                             scrollDirection: Axis.horizontal,
                                             child: Row(
-                                                children:
-                                                    tags.map((String tag) {
+                                                children: inputFieldValues.tags
+                                                    .map((tag) {
                                               return Container(
                                                 decoration: BoxDecoration(
                                                   borderRadius:
@@ -273,22 +274,21 @@ class CreateRoomScreen extends StatelessWidget {
                                                             .withOpacity(0.7),
                                                       ),
                                                       onTap: () {
-                                                        onTagDelete(tag);
+                                                        inputFieldValues
+                                                            .onTagDelete(tag);
                                                       },
                                                     )
                                                   ],
                                                 ),
                                               );
-                                            }).toList()),
+                                            }).toList() as List<Widget>),
                                           )
                                         : null,
                                   ),
-                                  onChanged: onChanged,
-                                  onSubmitted: onSubmitted,
+                                  onChanged: inputFieldValues.onChanged,
+                                  onSubmitted: inputFieldValues.onSubmitted,
                                 );
-                              });
-                            },
-                          ),
+                              }),
                           SizedBox(
                             height: UiSizes.height_33,
                           ),

--- a/lib/views/screens/tabview_screen.dart
+++ b/lib/views/screens/tabview_screen.dart
@@ -111,7 +111,8 @@ class TabViewScreen extends StatelessWidget {
                           await createRoomController.createRoom(
                               createRoomController.nameController.text,
                               createRoomController.descriptionController.text,
-                              createRoomController.tagsController.getTags!,
+                              createRoomController.tagsController.getTags!
+                                  as List<String>,
                               true);
                           await roomsController.getRooms();
                         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,23 +6,23 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "67.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "737321f9be522620ed3794937298fb0027a48a402624fa2500f7532f94aea810"
-      url: "https://pub.flutter-io.cn"
+      sha256: f5628cd9c92ed11083f425fd1f8f1bc60ecdda458c81d73b143aeda036c35fe7
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.22"
+    version: "1.3.16"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   animated_bottom_navigation_bar:
@@ -30,7 +30,7 @@ packages:
     description:
       name: animated_bottom_navigation_bar
       sha256: "2b04a2ae4b0742669e60ddf309467d6a354cefd2d0cd20f4737b1efaf9834cda"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   animated_splash_screen:
@@ -38,7 +38,7 @@ packages:
     description:
       name: animated_splash_screen
       sha256: f45634db6ec4e8cf034c53e03f3bd83898a16fe3c9286bf5510b6831dfcf2124
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   ansicolor:
@@ -46,23 +46,23 @@ packages:
     description:
       name: ansicolor
       sha256: "8bf17a8ff6ea17499e40a2d2542c2f481cd7615760c6d34065cb22bfd22e6880"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   app_links:
     dependency: "direct main"
     description:
       name: app_links
-      sha256: "4e392b5eba997df356ca6021f28431ce1cfeb16758699553a94b13add874a3bb"
-      url: "https://pub.flutter-io.cn"
+      sha256: "3ced568a5d9e309e99af71285666f1f3117bddd0bd5b3317979dccc1a40cada4"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   appwrite:
     dependency: "direct main"
     description:
       name: appwrite
       sha256: "2a277dcaddc3423efab14ce83f0bb64294cf6acf43937fd1ccf925b3474bbcb9"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "9.0.1"
   archive:
@@ -70,7 +70,7 @@ packages:
     description:
       name: archive
       sha256: "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.10"
   args:
@@ -78,7 +78,7 @@ packages:
     description:
       name: args
       sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   async:
@@ -86,7 +86,7 @@ packages:
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   boolean_selector:
@@ -94,7 +94,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   build:
@@ -102,7 +102,7 @@ packages:
     description:
       name: build
       sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   build_config:
@@ -110,7 +110,7 @@ packages:
     description:
       name: build_config
       sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
@@ -118,7 +118,7 @@ packages:
     description:
       name: build_daemon
       sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   build_resolvers:
@@ -126,7 +126,7 @@ packages:
     description:
       name: build_resolvers
       sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   build_runner:
@@ -134,7 +134,7 @@ packages:
     description:
       name: build_runner
       sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.8"
   build_runner_core:
@@ -142,7 +142,7 @@ packages:
     description:
       name: build_runner_core
       sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.0"
   built_collection:
@@ -150,7 +150,7 @@ packages:
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -158,7 +158,7 @@ packages:
     description:
       name: built_value
       sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.9.1"
   characters:
@@ -166,7 +166,7 @@ packages:
     description:
       name: characters
       sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   charcode:
@@ -174,7 +174,7 @@ packages:
     description:
       name: charcode
       sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   checked_yaml:
@@ -182,7 +182,7 @@ packages:
     description:
       name: checked_yaml
       sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   circular_countdown_timer:
@@ -190,7 +190,7 @@ packages:
     description:
       name: circular_countdown_timer
       sha256: "9ba5fbc076cedbcbf6190ed86762e679f43d7c67cdd903ea34df059dabdc08d4"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
   clock:
@@ -198,7 +198,7 @@ packages:
     description:
       name: clock
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
@@ -206,7 +206,7 @@ packages:
     description:
       name: code_builder
       sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.10.0"
   collection:
@@ -214,7 +214,7 @@ packages:
     description:
       name: collection
       sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
   connectivity_plus:
@@ -222,7 +222,7 @@ packages:
     description:
       name: connectivity_plus
       sha256: "77a180d6938f78ca7d2382d2240eb626c0f6a735d0bfdce227d8ffb80f95c48b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   connectivity_plus_platform_interface:
@@ -230,7 +230,7 @@ packages:
     description:
       name: connectivity_plus_platform_interface
       sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.4"
   convert:
@@ -238,7 +238,7 @@ packages:
     description:
       name: convert
       sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   cookie_jar:
@@ -246,23 +246,23 @@ packages:
     description:
       name: cookie_jar
       sha256: a6ac027d3ed6ed756bfce8f3ff60cb479e266f3b0fdabd6242b804b6765e52de
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.8"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
-      url: "https://pub.flutter-io.cn"
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+8"
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   cryptography:
@@ -270,7 +270,7 @@ packages:
     description:
       name: cryptography
       sha256: d146b76d33d94548cf035233fbc2f4338c1242fa119013bead807d033fc4ae05
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   csslib:
@@ -278,7 +278,7 @@ packages:
     description:
       name: csslib
       sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   cupertino_icons:
@@ -286,7 +286,7 @@ packages:
     description:
       name: cupertino_icons
       sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   custom_refresh_indicator:
@@ -294,23 +294,23 @@ packages:
     description:
       name: custom_refresh_indicator
       sha256: "65a463f09623f6baf75e45e0c9034e9304810be3f5dfb00a54edde7252f4a524"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368"
-      url: "https://pub.flutter-io.cn"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.6"
   dart_webrtc:
     dependency: transitive
     description:
       name: dart_webrtc
       sha256: a34e59ac1559cac954e48c9fe156164992163d2f4b7e75d5b0e927ee2f1e4922
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.16"
   dbus:
@@ -318,7 +318,7 @@ packages:
     description:
       name: dbus
       sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
   device_info_plus:
@@ -326,7 +326,7 @@ packages:
     description:
       name: device_info_plus
       sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "9.1.2"
   device_info_plus_platform_interface:
@@ -334,7 +334,7 @@ packages:
     description:
       name: device_info_plus_platform_interface
       sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
   fake_async:
@@ -342,23 +342,23 @@ packages:
     description:
       name: fake_async
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
-      url: "https://pub.flutter-io.cn"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
       name: file
       sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
   file_selector_linux:
@@ -366,7 +366,7 @@ packages:
     description:
       name: file_selector_linux
       sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.2+1"
   file_selector_macos:
@@ -374,7 +374,7 @@ packages:
     description:
       name: file_selector_macos
       sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.3+3"
   file_selector_platform_interface:
@@ -382,7 +382,7 @@ packages:
     description:
       name: file_selector_platform_interface
       sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.2"
   file_selector_windows:
@@ -390,87 +390,87 @@ packages:
     description:
       name: file_selector_windows
       sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.3+1"
   firebase_analytics:
     dependency: "direct main"
     description:
       name: firebase_analytics
-      sha256: "54681f6a8c35ec782c86680919953edbae66517a718fe7606a7ba52cfa1b36ca"
-      url: "https://pub.flutter-io.cn"
+      sha256: "0240076090d77045d757aecb090616066d23b343840d4c21074094d6fe40a184"
+      url: "https://pub.dev"
     source: hosted
-    version: "10.8.6"
+    version: "10.8.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: cf7378f407c26fd1f1cc808c0d791f2a15dd4f1fe0626bb2ce6a96663c4d8470
-      url: "https://pub.flutter-io.cn"
+      sha256: "6d9baa077d16b47ef5f19d982c4fc475597991aa53b0c601216faa3e1cdab45f"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.9.6"
+    version: "3.9.0"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: f62c7a2514771f6e122c5b55227c0c7fdaa253cc2fe6efce768897c0fb68a5ab
-      url: "https://pub.flutter-io.cn"
+      sha256: "89a740249bce9d52a99db4e501be6087ca6749c73c47cff2b174802be10abd81"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.5.5+18"
+    version: "0.5.5+12"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "7e049e32a9d347616edb39542cf92cd53fdb4a99fb6af0a0bff327c14cd76445"
-      url: "https://pub.flutter-io.cn"
+      sha256: "96607c0e829a581c2a483c658f04e8b159964c3bae2730f73297070bc85d40bb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.25.4"
+    version: "2.24.2"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       sha256: c437ae5d17e6b5cc7981cf6fd458a5db4d12979905f9aafd1fea930428a9fe63
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "57e61d6010e253b36d38191cefd6199d7849152cdcd234b61ca290cdb278a0ba"
-      url: "https://pub.flutter-io.cn"
+      sha256: d585bdf3c656c3f7821ba1bd44da5f13365d22fcecaf5eb75c4295246aaa83c0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.11.4"
+    version: "2.10.0"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       sha256: "53952a6f7860c44429bec80719c411e0ff77ce6cf31fade1515c7bdd87abe4a1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "14.7.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "789a3b26097e2bdad15a407dc552d6af74287b477ceb4aa6ec0d8aa967caf9e5"
-      url: "https://pub.flutter-io.cn"
+      sha256: "54e283a0e41d81d854636ad0dad73066adc53407a60a7c3189c9656e2f1b6107"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.5.24"
+    version: "4.5.18"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "156a83d281bbcc92b17496f323c747802287520aece51a893a5fdb8078bccbe7"
-      url: "https://pub.flutter-io.cn"
+      sha256: "90dc7ed885e90a24bb0e56d661d4d2b5f84429697fd2cbb9e5890a0ca370e6f4"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.6.5"
+    version: "3.5.18"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter:
@@ -483,23 +483,23 @@ packages:
     description:
       name: flutter_lints
       sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   flutter_local_notifications:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: c18f1de98fe0bb9dd5ba91e1330d4febc8b6a7de6aae3ffe475ef423723e72f3
-      url: "https://pub.flutter-io.cn"
+      sha256: "55b9b229307a10974b26296ff29f2e132256ba4bd74266939118eaefa941cb00"
+      url: "https://pub.dev"
     source: hosted
-    version: "16.3.2"
+    version: "16.3.3"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
       sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0+1"
   flutter_local_notifications_platform_interface:
@@ -507,7 +507,7 @@ packages:
     description:
       name: flutter_local_notifications_platform_interface
       sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0+1"
   flutter_native_splash:
@@ -515,7 +515,7 @@ packages:
     description:
       name: flutter_native_splash
       sha256: "558f10070f03ee71f850a78f7136ab239a67636a294a44a06b6b7345178edb1e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.10"
   flutter_onboarding_slider:
@@ -523,7 +523,7 @@ packages:
     description:
       name: flutter_onboarding_slider
       sha256: "70d6b7c8d469abb31f66fd80c61915d7ff9c05d2c9001ec7db659702e7bc4f9d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
   flutter_otp_text_field:
@@ -531,7 +531,7 @@ packages:
     description:
       name: flutter_otp_text_field
       sha256: c9164ba391071fb9783698256ddbb9efc960cfed056d843db164711c65b1b114
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   flutter_plugin_android_lifecycle:
@@ -539,7 +539,7 @@ packages:
     description:
       name: flutter_plugin_android_lifecycle
       sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.17"
   flutter_secure_storage:
@@ -547,7 +547,7 @@ packages:
     description:
       name: flutter_secure_storage
       sha256: "22dbf16f23a4bcf9d35e51be1c84ad5bb6f627750565edd70dab70f3ff5fff8f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.0"
   flutter_secure_storage_linux:
@@ -555,7 +555,7 @@ packages:
     description:
       name: flutter_secure_storage_linux
       sha256: "3d5032e314774ee0e1a7d0a9f5e2793486f0dff2dd9ef5a23f4e3fb2a0ae6a9e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   flutter_secure_storage_macos:
@@ -563,7 +563,7 @@ packages:
     description:
       name: flutter_secure_storage_macos
       sha256: bd33935b4b628abd0b86c8ca20655c5b36275c3a3f5194769a7b3f37c905369c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   flutter_secure_storage_platform_interface:
@@ -571,7 +571,7 @@ packages:
     description:
       name: flutter_secure_storage_platform_interface
       sha256: "0d4d3a5dd4db28c96ae414d7ba3b8422fd735a8255642774803b2532c9a61d7e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   flutter_secure_storage_web:
@@ -579,7 +579,7 @@ packages:
     description:
       name: flutter_secure_storage_web
       sha256: "30f84f102df9dcdaa2241866a958c2ec976902ebdaa8883fbfe525f1f2f3cf20"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_secure_storage_windows:
@@ -587,7 +587,7 @@ packages:
     description:
       name: flutter_secure_storage_windows
       sha256: "38f9501c7cb6f38961ef0e1eacacee2b2d4715c63cc83fe56449c4d3d0b47255"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   flutter_speed_dial:
@@ -595,7 +595,7 @@ packages:
     description:
       name: flutter_speed_dial
       sha256: "698a037274a66dbae8697c265440e6acb6ab6cae9ac5f95c749e7944d8f28d41"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
   flutter_svg:
@@ -603,7 +603,7 @@ packages:
     description:
       name: flutter_svg
       sha256: d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.9"
   flutter_test:
@@ -616,7 +616,7 @@ packages:
     description:
       name: flutter_web_auth_2
       sha256: "0da41e631a368e02366fc1a9b79dd8da191e700a836878bc54466fff51c07df2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   flutter_web_auth_2_platform_interface:
@@ -624,7 +624,7 @@ packages:
     description:
       name: flutter_web_auth_2_platform_interface
       sha256: f6fa7059ff3428c19cd756c02fef8eb0147131c7e64591f9060c90b5ab84f094
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   flutter_web_plugins:
@@ -637,7 +637,7 @@ packages:
     description:
       name: flutter_webrtc
       sha256: c2d244e422687a84d88af4ed2dcacc21cf76f156b4f2e9443123e42f1cceadc0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.32"
   flutter_window_close:
@@ -645,7 +645,7 @@ packages:
     description:
       name: flutter_window_close
       sha256: "63f5846efbf0974ec233e6b5f468aa604a4857157f4c6c44fd482621804a0464"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
   focused_menu:
@@ -653,7 +653,7 @@ packages:
     description:
       name: focused_menu
       sha256: bd06bf580a8573e100571a1d9bc27c2200a38681de30eeda96246df1eac06749
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   font_awesome_flutter:
@@ -661,7 +661,7 @@ packages:
     description:
       name: font_awesome_flutter
       sha256: "275ff26905134bcb59417cf60ad979136f1f8257f2f449914b2c3e05bbb4cd6f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "10.7.0"
   freezed:
@@ -669,7 +669,7 @@ packages:
     description:
       name: freezed
       sha256: "57247f692f35f068cae297549a46a9a097100685c6780fe67177503eea5ed4e5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.7"
   freezed_annotation:
@@ -677,7 +677,7 @@ packages:
     description:
       name: freezed_annotation
       sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   frontend_server_client:
@@ -685,7 +685,7 @@ packages:
     description:
       name: frontend_server_client
       sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   get:
@@ -693,7 +693,7 @@ packages:
     description:
       name: get
       sha256: e4e7335ede17452b391ed3b2ede016545706c01a02292a6c97619705e7d2a85e
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.6.6"
   get_storage:
@@ -701,7 +701,7 @@ packages:
     description:
       name: get_storage
       sha256: "39db1fffe779d0c22b3a744376e86febe4ade43bf65e06eab5af707dc84185a2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   glob:
@@ -709,7 +709,7 @@ packages:
     description:
       name: glob
       sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   google_fonts:
@@ -717,7 +717,7 @@ packages:
     description:
       name: google_fonts
       sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
   graphs:
@@ -725,7 +725,7 @@ packages:
     description:
       name: graphs
       sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   gtk:
@@ -733,7 +733,7 @@ packages:
     description:
       name: gtk
       sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   html:
@@ -741,7 +741,7 @@ packages:
     description:
       name: html
       sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.4"
   http:
@@ -749,7 +749,7 @@ packages:
     description:
       name: http
       sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.6"
   http_multi_server:
@@ -757,7 +757,7 @@ packages:
     description:
       name: http_multi_server
       sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
@@ -765,7 +765,7 @@ packages:
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   image:
@@ -773,7 +773,7 @@ packages:
     description:
       name: image
       sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.7"
   image_cropper:
@@ -781,7 +781,7 @@ packages:
     description:
       name: image_cropper
       sha256: "542c3453109d16bcc388e43ae2276044d2cd6a6d20c68bdcff2c94ab9363ea15"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
   image_cropper_for_web:
@@ -789,7 +789,7 @@ packages:
     description:
       name: image_cropper_for_web
       sha256: "89c936aa772a35b69ca67b78049ae9fa163a4fb8da2f6dee3893db8883fb49d2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   image_cropper_platform_interface:
@@ -797,7 +797,7 @@ packages:
     description:
       name: image_cropper_platform_interface
       sha256: b232175c132b2f7ede3e1f101652bcd635cb4079a77c6dded8e6d32e6578d685
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   image_picker:
@@ -805,7 +805,7 @@ packages:
     description:
       name: image_picker
       sha256: b6951e25b795d053a6ba03af5f710069c99349de9341af95155d52665cb4607c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.9"
   image_picker_android:
@@ -813,7 +813,7 @@ packages:
     description:
       name: image_picker_android
       sha256: "39f2bfe497e495450c81abcd44b62f56c2a36a37a175da7d137b4454977b51b1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.9+3"
   image_picker_for_web:
@@ -821,7 +821,7 @@ packages:
     description:
       name: image_picker_for_web
       sha256: "869fe8a64771b7afbc99fc433a5f7be2fea4d1cb3d7c11a48b6b579eb9c797f0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   image_picker_ios:
@@ -829,7 +829,7 @@ packages:
     description:
       name: image_picker_ios
       sha256: fadafce49e8569257a0cad56d24438a6fa1f0cbd7ee0af9b631f7492818a4ca3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.9+1"
   image_picker_linux:
@@ -837,7 +837,7 @@ packages:
     description:
       name: image_picker_linux
       sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
   image_picker_macos:
@@ -845,23 +845,23 @@ packages:
     description:
       name: image_picker_macos
       sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: fa4e815e6fcada50e35718727d83ba1c92f1edf95c0b4436554cec301b56233b
-      url: "https://pub.flutter-io.cn"
+      sha256: "3d2c323daea9d60608f1caf30be32a938916f4975434b8352e6f73dae496da38"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.3"
+    version: "2.9.4"
   image_picker_windows:
     dependency: transitive
     description:
       name: image_picker_windows
       sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
   internet_connection_checker_plus:
@@ -869,7 +869,7 @@ packages:
     description:
       name: internet_connection_checker_plus
       sha256: "8efb327ee79b2ca7f9c05254f004a28c7dd65358bd7b51f56c4db6b38de0833f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   intl:
@@ -877,7 +877,7 @@ packages:
     description:
       name: intl
       sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.0"
   io:
@@ -885,7 +885,7 @@ packages:
     description:
       name: io
       sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
@@ -893,7 +893,7 @@ packages:
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   js_bindings:
@@ -901,7 +901,7 @@ packages:
     description:
       name: js_bindings
       sha256: b3374fe1ac1f4a1058f570ab39ae8ada29458c4affaa1ace2772e0abaa5d080f
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.2+2"
   json_annotation:
@@ -909,7 +909,7 @@ packages:
     description:
       name: json_annotation
       sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
   json_serializable:
@@ -917,7 +917,7 @@ packages:
     description:
       name: json_serializable
       sha256: aa1f5a8912615733e0fdc7a02af03308933c93235bdc8d50d0b0c8a8ccb0b969
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
   language_picker:
@@ -925,31 +925,39 @@ packages:
     description:
       name: language_picker
       sha256: "1f5293675ec1359b72979dac8f8d4662d18d6d1b0a484343367cfbbbbcfca3f3"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.3"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "04be76c4a4bb50f14904e64749237e541e7c7bcf7ec0b196907322ab5d2fc739"
-      url: "https://pub.flutter-io.cn"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
     source: hosted
-    version: "9.0.16"
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: b06739349ec2477e943055aea30172c5c7000225f79dad4702e2ec0eda79a6ff
-      url: "https://pub.flutter-io.cn"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
       sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   livekit_client:
@@ -957,7 +965,7 @@ packages:
     description:
       name: livekit_client
       sha256: "80f9c4bb05cfc3bac743c208b23aafc3ba5b8d97d37f9feb85548ae6d386b150"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   loading_animation_widget:
@@ -965,7 +973,7 @@ packages:
     description:
       name: loading_animation_widget
       sha256: "1901682600273a966c34cf44a85fc5355da92a8d08a8a43c11adc4e471993e3a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0+4"
   loading_indicator:
@@ -973,7 +981,7 @@ packages:
     description:
       name: loading_indicator
       sha256: a101ffb2aa3e646137d7810bfa90b50525dd3f72c01235b6df7491cf6af6f284
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   logging:
@@ -981,23 +989,23 @@ packages:
     description:
       name: logging
       sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
-      url: "https://pub.flutter-io.cn"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
   meta:
@@ -1005,7 +1013,7 @@ packages:
     description:
       name: meta
       sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   mime:
@@ -1013,7 +1021,7 @@ packages:
     description:
       name: mime
       sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   nested:
@@ -1021,7 +1029,7 @@ packages:
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   nm:
@@ -1029,7 +1037,7 @@ packages:
     description:
       name: nm
       sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
   package_config:
@@ -1037,7 +1045,7 @@ packages:
     description:
       name: package_config
       sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_info_plus:
@@ -1045,7 +1053,7 @@ packages:
     description:
       name: package_info_plus
       sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
   package_info_plus_platform_interface:
@@ -1053,7 +1061,7 @@ packages:
     description:
       name: package_info_plus_platform_interface
       sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   page_transition:
@@ -1061,23 +1069,23 @@ packages:
     description:
       name: page_transition
       sha256: dee976b1f23de9bbef5cd512fe567e9f6278caee11f5eaca9a2115c19dc49ef6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
-      url: "https://pub.flutter-io.cn"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
       sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_provider:
@@ -1085,7 +1093,7 @@ packages:
     description:
       name: path_provider
       sha256: b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_android:
@@ -1093,7 +1101,7 @@ packages:
     description:
       name: path_provider_android
       sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   path_provider_foundation:
@@ -1101,7 +1109,7 @@ packages:
     description:
       name: path_provider_foundation
       sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   path_provider_linux:
@@ -1109,7 +1117,7 @@ packages:
     description:
       name: path_provider_linux
       sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
@@ -1117,7 +1125,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_windows:
@@ -1125,7 +1133,7 @@ packages:
     description:
       name: path_provider_windows
       sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   petitparser:
@@ -1133,7 +1141,7 @@ packages:
     description:
       name: petitparser
       sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
   platform:
@@ -1141,7 +1149,7 @@ packages:
     description:
       name: platform
       sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
   platform_detect:
@@ -1149,7 +1157,7 @@ packages:
     description:
       name: platform_detect
       sha256: "08f4ee79c0e1c4858d37e06b22352a3ebdef5466b613749a3adb03e703d4f5b0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.11"
   plugin_platform_interface:
@@ -1157,7 +1165,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   pointycastle:
@@ -1165,7 +1173,7 @@ packages:
     description:
       name: pointycastle
       sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.7.4"
   pool:
@@ -1173,7 +1181,7 @@ packages:
     description:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
@@ -1181,23 +1189,23 @@ packages:
     description:
       name: protobuf
       sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: "9a96a0a19b594dbc5bf0f1f27d2bc67d5f95957359b461cd9feb44ed6ae75096"
-      url: "https://pub.flutter-io.cn"
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pubspec_parse:
@@ -1205,7 +1213,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
   random_string:
@@ -1213,7 +1221,7 @@ packages:
     description:
       name: random_string
       sha256: "03b52435aae8cbdd1056cf91bfc5bf845e9706724dd35ae2e99fa14a1ef79d02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   recase:
@@ -1221,7 +1229,7 @@ packages:
     description:
       name: recase
       sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   rxdart:
@@ -1229,7 +1237,7 @@ packages:
     description:
       name: rxdart
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   share_plus:
@@ -1237,7 +1245,7 @@ packages:
     description:
       name: share_plus
       sha256: "3ef39599b00059db0990ca2e30fca0a29d8b37aae924d60063f8e0184cf20900"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.2"
   share_plus_platform_interface:
@@ -1245,7 +1253,7 @@ packages:
     description:
       name: share_plus_platform_interface
       sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
   shelf:
@@ -1253,7 +1261,7 @@ packages:
     description:
       name: shelf
       sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   shelf_web_socket:
@@ -1261,7 +1269,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   shimmer:
@@ -1269,7 +1277,7 @@ packages:
     description:
       name: shimmer
       sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   simple_progress_indicators:
@@ -1277,7 +1285,7 @@ packages:
     description:
       name: simple_progress_indicators
       sha256: f914a6a81633eae593babbdf78bc26a06d6ec09685a05d53aa2bc45bba228f60
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   sky_engine:
@@ -1290,7 +1298,7 @@ packages:
     description:
       name: source_gen
       sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   source_helper:
@@ -1298,7 +1306,7 @@ packages:
     description:
       name: source_helper
       sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.4"
   source_span:
@@ -1306,7 +1314,7 @@ packages:
     description:
       name: source_span
       sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stack_trace:
@@ -1314,23 +1322,23 @@ packages:
     description:
       name: stack_trace
       sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
   stop_watch_timer:
     dependency: "direct main"
     description:
       name: stop_watch_timer
-      sha256: e1a295f54742bdbed3ac2a9ec7e3e4f2f815a4e17180858af5f6a81426de3ea0
-      url: "https://pub.flutter-io.cn"
+      sha256: "9128717892ac94094e61544cb5259aff79eefebc0c4549a46d815689c56be8a7"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+4"
+    version: "3.1.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   stream_transform:
@@ -1338,7 +1346,7 @@ packages:
     description:
       name: stream_transform
       sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
@@ -1346,7 +1354,7 @@ packages:
     description:
       name: string_scanner
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   synchronized:
@@ -1354,7 +1362,7 @@ packages:
     description:
       name: synchronized
       sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0+1"
   term_glyph:
@@ -1362,7 +1370,7 @@ packages:
     description:
       name: term_glyph
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
@@ -1370,23 +1378,23 @@ packages:
     description:
       name: test_api
       sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
   textfield_tags:
     dependency: "direct main"
     description:
       name: textfield_tags
-      sha256: c1d215f481e7e8da5c79719825e595db4f829bf1ad3fce4c7ce43d340aa72683
-      url: "https://pub.flutter-io.cn"
+      sha256: "4295bcb2844022356b3808a4e5bc355e1ba8405e6a2028165863c55e9085e1eb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.1"
   timezone:
     dependency: transitive
     description:
       name: timezone
       sha256: "1cfd8ddc2d1cfd836bc93e67b9be88c3adaeca6f40a00ca999104c30693cdca0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.2"
   timing:
@@ -1394,7 +1402,7 @@ packages:
     description:
       name: timing
       sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   typed_data:
@@ -1402,7 +1410,7 @@ packages:
     description:
       name: typed_data
       sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
   universal_html:
@@ -1410,7 +1418,7 @@ packages:
     description:
       name: universal_html
       sha256: "56536254004e24d9d8cfdb7dbbf09b74cf8df96729f38a2f5c238163e3d58971"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   universal_io:
@@ -1418,7 +1426,7 @@ packages:
     description:
       name: universal_io
       sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   url_launcher:
@@ -1426,7 +1434,7 @@ packages:
     description:
       name: url_launcher
       sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.2.5"
   url_launcher_android:
@@ -1434,23 +1442,23 @@ packages:
     description:
       name: url_launcher_android
       sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.0"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
-      url: "https://pub.flutter-io.cn"
+      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.2.5"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   url_launcher_macos:
@@ -1458,7 +1466,7 @@ packages:
     description:
       name: url_launcher_macos
       sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   url_launcher_platform_interface:
@@ -1466,23 +1474,23 @@ packages:
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
-      url: "https://pub.flutter-io.cn"
+      sha256: "3692a459204a33e04bc94f5fb91158faf4f2c8903281ddd82915adecdb1a901d"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   uuid:
@@ -1490,7 +1498,7 @@ packages:
     description:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vector_graphics:
@@ -1498,7 +1506,7 @@ packages:
     description:
       name: vector_graphics
       sha256: "4ac59808bbfca6da38c99f415ff2d3a5d7ca0a6b4809c71d9cf30fba5daf9752"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.10+1"
   vector_graphics_codec:
@@ -1506,7 +1514,7 @@ packages:
     description:
       name: vector_graphics_codec
       sha256: f3247e7ab0ec77dc759263e68394990edc608fb2b480b80db8aa86ed09279e33
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.10+1"
   vector_graphics_compiler:
@@ -1514,7 +1522,7 @@ packages:
     description:
       name: vector_graphics_compiler
       sha256: "18489bdd8850de3dd7ca8a34e0c446f719ec63e2bab2e7a8cc66a9028dd76c5a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.10+1"
   vector_math:
@@ -1522,7 +1530,7 @@ packages:
     description:
       name: vector_math
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   vm_service:
@@ -1530,7 +1538,7 @@ packages:
     description:
       name: vm_service
       sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
   watcher:
@@ -1538,31 +1546,31 @@ packages:
     description:
       name: watcher
       sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: edc8a9573dd8c5a83a183dae1af2b6fd4131377404706ca4e5420474784906fa
-      url: "https://pub.flutter-io.cn"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
-      url: "https://pub.flutter-io.cn"
+      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   webrtc_interface:
     dependency: transitive
     description:
       name: webrtc_interface
       sha256: "0ac4693f921c81005edefd2f43b9fe84b0ed54481474fe1ee16b789b0c84a77c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.13"
   win32:
@@ -1570,7 +1578,7 @@ packages:
     description:
       name: win32
       sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.2.0"
   win32_registry:
@@ -1578,7 +1586,7 @@ packages:
     description:
       name: win32_registry
       sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   window_to_front:
@@ -1586,7 +1594,7 @@ packages:
     description:
       name: window_to_front
       sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.0.3"
   xdg_directories:
@@ -1594,7 +1602,7 @@ packages:
     description:
       name: xdg_directories
       sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   xml:
@@ -1602,7 +1610,7 @@ packages:
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
   yaml:
@@ -1610,9 +1618,9 @@ packages:
     description:
       name: yaml
       sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.16.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   json_annotation: ^4.8.1
   font_awesome_flutter: ^10.4.0
   animated_bottom_navigation_bar: ^1.2.0
-  textfield_tags: ^2.0.2
+  textfield_tags: ^2.1.1
   animated_splash_screen: ^1.3.0
   flutter_native_splash: ^2.2.19
   page_transition: ^2.0.9


### PR DESCRIPTION
## Description

This PR addresses the issue where a `Null check operator used on a null value` exception is thrown when trying to access `Get.width` and `Get.height` in the `UiSizes` class before the `BuildContext` is available.

The solution involves refactoring the `UiSizes` class to use `late` keyword for the size variables and initializing them in a new `init` method which is called after the `BuildContext` is available. 'MediaQuery' is used to get the screen sizes.
Fixes #288 

## Changes:
1. Refactored the `UiSizes` class to use `late` keyword for the size variables.
2.  Added an `init` method in `UiSizes` class to initialize the size variables using `MediaQuery`.
3. Called `UiSizes.init()` in the `build` method of the main widget.

## How Has This Been Tested?

1. Run the app to ensure it loads without throwing the `Null check operator used on a null value` exception.
2. Check various parts of the app to ensure that the sizes are being applied correctly.


 

https://github.com/AOSSIE-Org/Resonate/assets/144162711/57346fcb-7e5e-4e6b-9fd5-ed527b031c0a
![Screenshot (182)](https://github.com/AOSSIE-Org/Resonate/assets/144162711/1922b727-584a-470e-a4cb-a20029a52a6b)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] Tag the PR with the appropriate labels