### PR TITLE
Fix : handle Network image load Exception in discussion tile

### DIFF
--- a/lib/views/widgets/discussion_tile.dart
+++ b/lib/views/widgets/discussion_tile.dart
@@ -1,16 +1,10 @@
 import 'package:appwrite/models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get/get.dart';
-import 'package:resonate/controllers/create_room_controller.dart';
 import 'package:resonate/controllers/discussions_controller.dart';
-import 'package:resonate/controllers/rooms_controller.dart';
 import 'package:resonate/themes/theme_controller.dart';
 import 'package:resonate/utils/ui_sizes.dart';
-import 'package:share_plus/share_plus.dart';
-import '../../utils/colors.dart';
-import '../../utils/enums/room_state.dart';
 
 class DiscussionTile extends StatelessWidget {
   final Document discussion;
@@ -62,7 +56,7 @@ class DiscussionTile extends StatelessWidget {
     DateTime localDateTime = disscussionController.isOffsetNegetive
         ? UTCDateTime.subtract(disscussionController.localTimeZoneOffset)
         : UTCDateTime.add(disscussionController.localTimeZoneOffset);
-    String month_name =
+    String monthName =
         disscussionController.monthMap[localDateTime.month.toString()]!;
 
     hour = localDateTime.hour;
@@ -77,7 +71,7 @@ class DiscussionTile extends StatelessWidget {
     return Row(
       children: [
         Text(
-          '${localDateTime.day} ${month_name}',
+          '${localDateTime.day} $monthName',
           style: kTileSubtitleStyle,
         ),
         SizedBox(
@@ -172,7 +166,7 @@ class DiscussionTile extends StatelessWidget {
                     Row(
                       children: [
                         userIsCreator == null
-                            ? SizedBox.shrink()
+                            ? const SizedBox.shrink()
                             : !userIsCreator!
                                 ? Row(
                                     children: [
@@ -192,11 +186,11 @@ class DiscussionTile extends StatelessWidget {
                                       ),
                                     ],
                                   )
-                                : SizedBox(),
+                                : const SizedBox(),
                         ElevatedButton(
                             style: ElevatedButton.styleFrom(
                                 disabledBackgroundColor:
-                                    Color.fromARGB(183, 120, 118, 118),
+                                    const Color.fromARGB(183, 120, 118, 118),
                                 side: BorderSide(
                                     color: userIsCreator == null
                                         ? themeController.primaryColor.value
@@ -211,10 +205,11 @@ class DiscussionTile extends StatelessWidget {
                                 backgroundColor: userIsCreator == null
                                     ? Colors.black
                                     : (!userIsCreator!)
-                                        ? Color.fromARGB(155, 58, 190, 34)
+                                        ? const Color.fromARGB(155, 58, 190, 34)
                                         : themeController.loadTheme() == 'dark'
-                                            ? Color.fromARGB(51, 0, 143, 0)
-                                            : Color.fromARGB(
+                                            ? const Color.fromARGB(
+                                                51, 0, 143, 0)
+                                            : const Color.fromARGB(
                                                 220, 229, 248, 229),
                                 minimumSize:
                                     Size(UiSizes.width_80, UiSizes.height_30),
@@ -271,7 +266,7 @@ class DiscussionTile extends StatelessWidget {
                                   fontWeight: FontWeight.w100,
                                 ))),
                         userIsCreator == null
-                            ? SizedBox()
+                            ? const SizedBox()
                             : userIsCreator!
                                 ? Row(
                                     children: [
@@ -280,12 +275,13 @@ class DiscussionTile extends StatelessWidget {
                                       ),
                                       ElevatedButton(
                                           style: ElevatedButton.styleFrom(
-                                              side: BorderSide(
+                                              side: const BorderSide(
                                                   color: Color.fromARGB(
                                                       198, 100, 8, 3),
                                                   width: 1),
-                                              backgroundColor: Color.fromARGB(
-                                                  246, 243, 81, 81),
+                                              backgroundColor:
+                                                  const Color.fromARGB(
+                                                      246, 243, 81, 81),
                                               minimumSize: Size(
                                                   UiSizes.width_80,
                                                   UiSizes.height_30),
@@ -324,7 +320,7 @@ class DiscussionTile extends StatelessWidget {
                                               )))
                                     ],
                                   )
-                                : SizedBox(),
+                                : const SizedBox(),
                       ],
                     )
                   ],
@@ -334,7 +330,7 @@ class DiscussionTile extends StatelessWidget {
                 ),
                 buildTags(),
                 discussion.data["description"] == null
-                    ? SizedBox()
+                    ? const SizedBox()
                     : Column(
                         children: [
                           SizedBox(
@@ -383,9 +379,13 @@ class DiscussionTile extends StatelessWidget {
                               left: UiSizes.width_2,
                               top: UiSizes.height_2,
                               child: CircleAvatar(
+                                foregroundImage: NetworkImage(avatarImageUrl),
                                 backgroundColor: Colors.white,
                                 radius: UiSizes.size_16,
-                                backgroundImage: NetworkImage(avatarImageUrl),
+                                onForegroundImageError:
+                                    (exception, stackTrace) {
+                                  const ColoredBox(color: Colors.black);
+                                },
                               ),
                             ),
                           ],
@@ -394,7 +394,7 @@ class DiscussionTile extends StatelessWidget {
                     SizedBox(
                       width: UiSizes.width_16,
                     ),
-                    Text("${subscriberCount}+ Subscribed",
+                    Text("$subscriberCount+ Subscribed",
                         style: kTileSubtitleStyle),
                     const Spacer(),
                     FaIcon(


### PR DESCRIPTION
## Description
image of the user in discussion tile throw an Network Image Load Exception while user where scrolling  


Fixes #300 

## Type of change
add  on Foreground Image Error  attribute to catch error throwing when loading user image 


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
with my emulator 


Please include screenshots below if applicable.
exception thrown while user scrolling  
![Screenshot (1638)](https://github.com/AOSSIE-Org/Resonate/assets/118139061/00ed1782-2f6b-474a-96d7-dc72e2465f63)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels