### PR TITLE
Fix textfield tag error

### DIFF
--- a/lib/views/screens/create_room_screen.dart
+++ b/lib/views/screens/create_room_screen.dart
@@ -210,8 +210,19 @@ class CreateRoomScreen extends StatelessWidget {
                               initialTags: const ['sample-tag'],
                               textSeparators: const [' ', ','],
                               letterCase: LetterCase.normal,
-                              validator: (tag) =>
-                                  tag.isValidTag() ? null : "Invalid Tag",
+                              validator: (tag) {
+                                String? validateTag(dynamic tag) {
+                                  if (tag != null &&
+                                      tag is String &&
+                                      tag.isValidTag()) {
+                                    return null; // Tag is valid
+                                  } else {
+                                    return 'Invalid Tag: $tag'; // Return an error message for invalid tags
+                                  }
+                                }
+
+                                return validateTag(tag);
+                              },
                               inputFieldBuilder: (context, inputFieldValues) {
                                 return TextField(
                                   style: TextStyle(fontSize: UiSizes.size_20),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -972,10 +972,10 @@ packages:
     dependency: "direct main"
     description:
       name: loading_animation_widget
-      sha256: "1901682600273a966c34cf44a85fc5355da92a8d08a8a43c11adc4e471993e3a"
+      sha256: ee3659035528d19145d50cf0107632bf647e7306c88b6a32f35f3bed63f6d728
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0+4"
+    version: "1.2.1"
   loading_indicator:
     dependency: "direct main"
     description:
@@ -1380,7 +1380,7 @@ packages:
       sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   textfield_tags:
     dependency: "direct main"
     description:
@@ -1548,8 +1548,8 @@ packages:
       sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "14.0.0"
-  watcher:
+    version: "1.1.0"
+  web:
     dependency: transitive
     description:
       name: web
@@ -1577,10 +1577,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
+      sha256: "8cb58b45c47dcb42ab3651533626161d6b67a2921917d8d429791f76972b3480"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.3.0"
   win32_registry:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description
This pull request addresses issue #307 .
This PR solves the issue with textfield_tags where error "String' has no instance named 'isValidTag" was thrown after a tag was entered in the textfield.

Changes:-
Defines an inline function validateTag() within the scope of the validator.
Encapsulates the validation logic within this function.
Provides better encapsulation and organization of validation logic, enhancing readability and maintainability.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Test manually on physical device.
Before:
![WhatsApp Image 2024-03-21 at 11 42 56_fb6d87fc](https://github.com/AOSSIE-Org/Resonate/assets/136071018/ae16400e-4261-4a8f-8818-85460ef0ef80)
After
![after](https://github.com/AOSSIE-Org/Resonate/assets/136071018/44ad226f-f51d-4514-b3fb-4f3725d4b13d)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels