### PR TITLE
 [ fix] pair chat icons fade when tapping on it.

### DIFF
--- a/lib/views/screens/pair_chat_screen.dart
+++ b/lib/views/screens/pair_chat_screen.dart
@@ -146,13 +146,18 @@ class PairChatScreen extends StatelessWidget {
                               },
                               backgroundColor: controller.isMicOn.value
                                   ? currentBrightness == Brightness.light
-                                      ? Colors.white
+                                      ? Colors.white.withOpacity(0.5)
                                       : Colors.white54
                                   : themeController.primaryColor.value,
-                              child: Icon(
-                                Icons.mic_off,
-                                size: UiSizes.size_24,
-                              ),
+                              child: controller.isMicOn.value
+                                  ? Icon(
+                                      Icons.mic,
+                                      size: UiSizes.size_24,
+                                    )
+                                  : Icon(
+                                      Icons.mic_off,
+                                      size: UiSizes.size_24,
+                                    ),
                             ),
                           ),
                           SizedBox(
@@ -178,7 +183,7 @@ class PairChatScreen extends StatelessWidget {
                               backgroundColor: controller.isLoudSpeakerOn.value
                                   ? themeController.primaryColor.value
                                   : currentBrightness == Brightness.light
-                                      ? Colors.white
+                                      ? Colors.white.withOpacity(0.5)
                                       : Colors.white54,
                               child: Icon(
                                 Icons.volume_up,


### PR DESCRIPTION
## Description

replaced the icon mic_off with icon mic_on when tapping and changed the background color opacity of the container to make icon appears on it 
Fixes #313 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
 
## How Has This Been Tested?
 

https://github.com/AOSSIE-Org/Resonate/assets/144162711/e7277d06-060d-4572-b53e-019fb32ca2ca


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels