### PR TITLE
[enhance] logout icon doesn't match with app color

### DIFF
--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -42,7 +42,7 @@ class ProfileScreen extends StatelessWidget {
                     },
                     child: const Icon(
                       Icons.logout_rounded,
-                      color: Colors.black,
+                      color: themeController.primaryColor.value,
                     )),
                 const SizedBox(
                   width: 20,


### PR DESCRIPTION
## Description

fix logout icon fades in dark theme 
Fixes #315 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
 

## How Has This Been Tested?

manually in android emulator

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels