### PR TITLE
Fix : Color of logout button fades in dark mode

### DIFF
--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -36,14 +36,22 @@ class ProfileScreen extends StatelessWidget {
             Row(
               children: [
                 InkWell(
-                    borderRadius: BorderRadius.circular(100),
-                    onTap: () async {
-                      await authStateController.logout();
+                  borderRadius: BorderRadius.circular(100),
+                  onTap: () async {
+                    await authStateController.logout();
+                  },
+                  child: StreamBuilder<Color>(
+                    stream: themeController.primaryColor.stream,
+                    initialData: themeController.primaryColor.value,
+                    builder: (context, snapshot) {
+                      final color = snapshot.data;
+                      return Icon(
+                        Icons.logout_rounded,
+                        color: color,
+                      );
                     },
-                    child: const Icon(
-                      Icons.logout_rounded,
-                      color: Colors.black,
-                    )),
+                  ),
+                ),
                 const SizedBox(
                   width: 20,
                 ),

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -27,40 +27,33 @@ class ProfileScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetBuilder<AuthStateController>(
-      builder: (controller) => Scaffold(
-        appBar: AppBar(
-          title: const Text(
-            "Profile",
-          ),
-          actions: [
-            Row(
-              children: [
-                InkWell(
-                  borderRadius: BorderRadius.circular(100),
-                  onTap: () async {
-                    await authStateController.logout();
-                  },
-                  child: StreamBuilder<Color>(
-                    stream: themeController.primaryColor.stream,
-                    initialData: themeController.primaryColor.value,
-                    builder: (context, snapshot) {
-                      final color = snapshot.data;
-                      return Icon(
-                        Icons.logout_rounded,
-                        color: color,
-                      );
+      builder: (controller) => Obx(() {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text(
+              "Profile",
+            ),
+            actions: [
+              Row(
+                children: [
+                  InkWell(
+                    borderRadius: BorderRadius.circular(100),
+                    onTap: () async {
+                      await authStateController.logout();
                     },
+                    child: Icon(
+                      Icons.logout_rounded,
+                      color: themeController.primaryColor.value,
+                    ),
                   ),
-                ),
-                const SizedBox(
-                  width: 20,
-                ),
-              ],
-            )
-          ],
-        ),
-        body: Obx(
-          () => Center(
+                  const SizedBox(
+                    width: 20,
+                  ),
+                ],
+              )
+            ],
+          ),
+          body: Center(
               child: Stack(children: [
             controller.isInitializing.value
                 ? BackdropFilter(
@@ -338,8 +331,8 @@ class ProfileScreen extends StatelessWidget {
                   )
                 : const SizedBox(),
           ])),
-        ),
-      ),
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
## Description

This PR resolve the issue with the color of logout button in profile screen.
Fixes https://github.com/AOSSIE-Org/Resonate/issues/315

Changes:
Directly updating the icon color with themeController.primaryColor.value was not working when i was switching to different color because in profile screen only body is wrapped with Obx and logout button lies outside the body .For reflecting the changes immediately on  logout button ,we have to wrap scaffold with Obx.

Fixes #315 

## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested Manually on physical device


https://github.com/AOSSIE-Org/Resonate/assets/136071018/add4d134-97d8-40a1-ba46-1a5cd6fc08f4



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels