### PR TITLE
Fix: Make login screen responsive by using height value from UiSizes

### DIFF
--- a/lib/views/screens/login_screen.dart
+++ b/lib/views/screens/login_screen.dart
@@ -34,7 +34,8 @@ class _LoginScreenState extends State<LoginScreen> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Container(
-            height: 780,
+            //Use height value from UiSizes to make the app responsive
+            height: UiSizes.height_780,
             padding: EdgeInsets.symmetric(
                 horizontal: UiSizes.width_20, vertical: UiSizes.height_10),
             child: Form(
@@ -130,10 +131,13 @@ class _LoginScreenState extends State<LoginScreen> {
                     alignment: Alignment.centerRight,
                     child: GestureDetector(
                       onTap: () {
-                        Navigator.push(context, MaterialPageRoute(builder: (context){
-                          return ForgotPasswordScreen();
-                        },
-                        ),
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return ForgotPasswordScreen();
+                            },
+                          ),
                         );
                       },
                       child: Text(


### PR DESCRIPTION
## Description

**Problem:**
Bottom overflowed error when user is on login screen.

**Preview of the problem:**
![Screenshot from 2024-05-14 09-28-07](https://github.com/AOSSIE-Org/Resonate/assets/55053472/dabeb7f0-fce7-4e30-967d-f94d52abbee4)

**Reason:**
Hard Coded value of `height=780` is used for setting height(line 38 of login_screen.dart) of the Container containing  login screen elements

**Fix:**
Set `height=UiSizes.height_780` to implement responsive design instead of using hard coded values

## Fixes
#287 : [Bug:- Bottom overflowed error on login screen](https://github.com/AOSSIE-Org/Resonate/issues/287)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
## How Has This Been Tested?

The changes are tested on Android Emulator (API 33: Pixel 8 Pro) and on Moto g40 Fusion(API 32). The changes fixes the bug without  raising any additional errors

**Preview After Fix:**
![Screenshot from 2024-05-14 09-33-29](https://github.com/AOSSIE-Org/Resonate/assets/55053472/790f9343-7890-446a-ae2d-067cdc994b9d)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels