### PR TITLE
Update chat screen to add more functionalities

### DIFF
--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -11,7 +11,7 @@ class Message {
   int index;
   bool isEdited;
   String content;
-  Duration creationDateTime;
+  DateTime creationDateTime;
   ReplyTo? replyTo;
 
 
@@ -43,7 +43,7 @@ class Message {
       'index': index,
       'isEdited': isEdited,
       'content': content,
-      'creationDateTime': creationDateTime.inMilliseconds, 
+      'creationDateTime': creationDateTime, 
       'replyTo': replyTo?.toJson(), 
     };
   }
@@ -60,6 +60,6 @@ class Message {
         index = json['index'],
         isEdited = json['isEdited'],
         content = json['content'],
-        creationDateTime = Duration(milliseconds: json['creationDateTime']),
+        creationDateTime = json['creationDateTime'],
         replyTo = json['replyTo'] != null ? ReplyTo.fromJson(json['replyTo']) : null;
 }

--- a/lib/views/screens/room_chat_screen.dart
+++ b/lib/views/screens/room_chat_screen.dart
@@ -1,59 +1,202 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:resonate/models/message.dart';
+import 'package:resonate/models/reply_to.dart';
 
-class RoomChatScreen extends StatelessWidget {
-  final List<Message> messages = [
-    Message(
-      name: 'Amar',
-      text: 'Hello Everyone, How are you?',
-      time: '2m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'John',
-      text: 'All Good, What about you?',
-      time: '3m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'Sara',
-      text: 'This topic is really interesting!',
-      time: '5m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'Michael',
-      text: 'I agree with you',
-      time: '10m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'Emma',
-      text: 'Hello Everyone, How are you?',
-      time: '12m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'Olivia',
-      text: 'Hiiii',
-      time: '15m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-    Message(
-      name: 'James',
-      text: 'Hello Everyone, How are you?',
-      time: '20m ago',
-      avatar:
-          'https://img.freepik.com/free-psd/3d-illustration-person-with-sunglasses_23-2149436188.jpg?ga=GA1.1.338869508.1708106114&semt=sph',
-    ),
-  ];
+class RoomChatScreen extends StatefulWidget {
+  const RoomChatScreen({super.key});
 
-  RoomChatScreen({super.key});
+  @override
+  State<RoomChatScreen> createState() => _RoomChatScreenState();
+}
+
+class _RoomChatScreenState extends State<RoomChatScreen> {
+  final ScrollController _scrollController = ScrollController();
+  final double itemHight = 80;
+
+  List<Message> messages = [
+    Message(
+      roomId: "room1",
+      messageId: "msg1",
+      creatorId: "user123",
+      creatorUsername: "john_doe",
+      creatorName: "John Doe",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 0,
+      isEdited: false,
+      content: "Hello, everyone! Welcome to the chat room.",
+      creationDateTime: DateTime.now(),
+      replyTo: null,
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg2",
+      creatorId: "user456",
+      creatorUsername: "jane_smith",
+      creatorName: "Jane Smith",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: false,
+      index: 1,
+      isEdited: false,
+      content: "Thanks, John! Happy to be here 😊",
+      creationDateTime: DateTime.now(),
+      replyTo: ReplyTo(
+        index: 0,
+        creatorUsername: "john_doe",
+        content: "Hello, everyone! Welcome to the chat room.",
+        creatorImgUrl:
+            "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      ),
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg3",
+      creatorId: "user789",
+      creatorUsername: "mike_jones",
+      creatorName: "Mike Jones",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 2,
+      isEdited: true,
+      content: "Good morning! Just edited my message to add this line.",
+      creationDateTime: DateTime.now(),
+      replyTo: null,
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg4",
+      creatorId: "user123",
+      creatorUsername: "john_doe",
+      creatorName: "John Doe",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 3,
+      isEdited: false,
+      content: "Nice to see everyone interacting. 😊",
+      creationDateTime: DateTime.now(),
+      replyTo: ReplyTo(
+        index: 2,
+        creatorUsername: "mike_jones",
+        content: "Good morning! Just edited my message to add this line.",
+        creatorImgUrl:
+            "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      ),
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg5",
+      creatorId: "user789",
+      creatorUsername: "mike_jones",
+      creatorName: "Mike Jones",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 4,
+      isEdited: true,
+      content: "Yes, it's a great day!",
+      creationDateTime: DateTime.now(),
+      replyTo: null,
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg6",
+      creatorId: "user456",
+      creatorUsername: "jane_smith",
+      creatorName: "Jane Smith",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: false,
+      index: 5,
+      isEdited: false,
+      content: "Totally agree, Mike!",
+      creationDateTime: DateTime.now(),
+      replyTo: ReplyTo(
+        index: 4,
+        creatorUsername: "mike_jones",
+        content: "Yes, it's a great day!",
+        creatorImgUrl:
+            "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      ),
+    ),
+    // Adding more messages for testing scrolling functionality
+    Message(
+      roomId: "room1",
+      messageId: "msg7",
+      creatorId: "user123",
+      creatorUsername: "john_doe",
+      creatorName: "John Doe",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 6,
+      isEdited: false,
+      content: "This chat is getting lively!",
+      creationDateTime: DateTime.now(),
+      replyTo: null,
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg8",
+      creatorId: "user789",
+      creatorUsername: "mike_jones",
+      creatorName: "Mike Jones",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 7,
+      isEdited: false,
+      content: "Totally! Let's keep it up.",
+      creationDateTime: DateTime.now(),
+      replyTo: ReplyTo(
+        index: 6,
+        creatorUsername: "john_doe",
+        content: "This chat is getting lively!",
+        creatorImgUrl:
+            "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      ),
+    ),
+    Message(
+      roomId: "room1",
+      messageId: "msg8",
+      creatorId: "user789",
+      creatorUsername: "mike_jones",
+      creatorName: "Mike Jones",
+      creatorImgUrl:
+          "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      hasValidTag: true,
+      index: 8,
+      isEdited: false,
+      content: "Totally! Let's keep it up.",
+      creationDateTime: DateTime.now(),
+      replyTo: ReplyTo(
+        index: 0,
+        creatorUsername: "john_doe",
+        content: "Hello, everyone! Welcome to the chat room.",
+        creatorImgUrl:
+            "https://storage.googleapis.com/fc-freepik-pro-rev1-eu-static/ai-styles-landings/cartoon/characters-and-scenes.jpg?h=1280",
+      ),
+    ),
+];
+
+  void scrollToMessage(int index) {
+    _scrollController.animateTo(
+      index * itemHight,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void updateMessage(int index, String newContent) {
+    setState(() {
+      messages[index].content = newContent;
+      messages[index].isEdited = true;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -78,10 +221,16 @@ class RoomChatScreen extends StatelessWidget {
         children: [
           Expanded(
             child: ListView.builder(
+              controller: _scrollController,
               padding: const EdgeInsets.all(16.0),
               itemCount: messages.length,
               itemBuilder: (context, index) {
-                return ChatMessageItem(message: messages[index]);
+                return ChatMessageItem(
+                  message: messages[index],
+                  onTapReply: (int replyIndex) => scrollToMessage(replyIndex),
+                  onEditMessage: (String newContent) =>
+                      updateMessage(index, newContent),
+                );
               },
             ),
           ),
@@ -92,56 +241,170 @@ class RoomChatScreen extends StatelessWidget {
   }
 }
 
-class Message {
-  final String name;
-  final String text;
-  final String time;
-  final String avatar;
+class ChatMessageItem extends StatefulWidget {
+  final Message message;
+  final void Function(int) onTapReply;
+  final void Function(String) onEditMessage;
 
-  Message(
-      {required this.name,
-      required this.text,
-      required this.time,
-      required this.avatar});
+  const ChatMessageItem({
+    Key? key,
+    required this.message,
+    required this.onTapReply,
+    required this.onEditMessage,
+  }) : super(key: key);
+
+  @override
+  _ChatMessageItemState createState() => _ChatMessageItemState();
 }
 
-class ChatMessageItem extends StatelessWidget {
-  final Message message;
+class _ChatMessageItemState extends State<ChatMessageItem> {
+  bool isEditing = false;
+  late TextEditingController _editingController;
 
-  const ChatMessageItem({Key? key, required this.message}) : super(key: key);
+  @override
+  void initState() {
+    super.initState();
+    _editingController = TextEditingController(text: widget.message.content);
+  }
+
+  @override
+  void dispose() {
+    _editingController.dispose();
+    super.dispose();
+  }
+
+  void startEditing() {
+    setState(() {
+      isEditing = true;
+    });
+    _editingController.selection = TextSelection.fromPosition(
+      TextPosition(offset: _editingController.text.length),
+    );
+  }
+
+  void saveEdit() {
+    widget.onEditMessage(_editingController.text);
+    setState(() {
+      isEditing = false;
+    });
+  }
+
+  void cancelEdit() {
+    setState(() {
+      isEditing = false;
+    });
+    _editingController.text = widget.message.content;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          CircleAvatar(
-            radius: 20,
-            backgroundImage: NetworkImage(
-                message.avatar), // Replace with actual image assets
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
+    return GestureDetector(
+      onDoubleTap: startEditing,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  message.name,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                CircleAvatar(
+                  radius: 20,
+                  backgroundImage: NetworkImage(widget.message.creatorImgUrl),
                 ),
-                const SizedBox(height: 5),
-                Text(message.text),
-                const SizedBox(height: 5),
-                Text(
-                  message.time,
-                  style: const TextStyle(color: Colors.grey, fontSize: 12),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.message.creatorName,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 5),
+                      if (widget.message.replyTo != null)
+                        GestureDetector(
+                          onTap: () =>
+                              widget.onTapReply(widget.message.replyTo!.index),
+                          child: Container(
+                            padding: const EdgeInsets.all(8),
+                            margin: const EdgeInsets.only(bottom: 5),
+                            decoration: BoxDecoration(
+                              color: Colors.grey[200],
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  "@${widget.message.replyTo!.creatorUsername}",
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.blue,
+                                  ),
+                                ),
+                                Text(
+                                  widget.message.replyTo!.content,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      if (isEditing)
+                        Focus(
+                          onKey: (node, event) {
+                            if (event.logicalKey == LogicalKeyboardKey.escape) {
+                              cancelEdit();
+                              return KeyEventResult.handled;
+                            }
+                            return KeyEventResult.ignored;
+                          },
+                          child: TextField(
+                            controller: _editingController,
+                            autofocus: true,
+                            onSubmitted: (value) => saveEdit(),
+                            onTapOutside: (event) => cancelEdit(),
+                            decoration: InputDecoration(
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(5),
+                              ),
+                              contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 10, vertical: 5),
+                            ),
+                          ),
+                        )
+                      else
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(widget.message.content),
+                            ),
+                            if (widget.message.isEdited)
+                              const Text(
+                                ' (edited)',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontStyle: FontStyle.italic,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                          ],
+                        ),
+                      const SizedBox(height: 5),
+                      Text(
+                        widget.message.creationDateTime.toString(),
+                        style:
+                            const TextStyle(color: Colors.grey, fontSize: 12),
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description

Updated chat screen to add more functionalities

- Message Replying: Users can reply to messages, with a tap to navigate to the original message.
- Smooth Scrolling: Automatically scrolls to referenced messages when tapped.
- Inline Editing: Double-tap to edit messages directly in the chat, with an "(edited)" label.
- Keyboard Shortcuts: "Enter" saves edits, "Esc" cancels them, and clicking outside cancels editing.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## Screenshots

https://github.com/user-attachments/assets/6744ca4e-be3f-477b-9180-a930baaa2351


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels