### PR TITLE
fix: renderoverflex error in profile_screen on some devices

### DIFF
--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -160,7 +160,7 @@ class ProfileScreen extends StatelessWidget {
                 isCreatorProfile != null
                     ? const Icon(Icons.add)
                     : const Icon(Icons.edit),
-                const SizedBox(width: 10),
+                const SizedBox(width: 8),
                 Text(isCreatorProfile != null ? "Follow" : "Edit Profile"),
               ],
             ),


### PR DESCRIPTION
## Description

This PR aims to fix a minor issue observed in some devices. The profile screen "Edit Profile" button faces RenderOverFlex error which is now almost completely removed.

#### This Directly fixes the Problem since no prior issues are available. Bug was found upon testing

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested on a real Android 14.0.1 Redmi Note 10 Pro device. Below are the screenshots:

Old | New
--- | ---
<img src="https://github.com/user-attachments/assets/f2431b25-12ab-4cea-9a28-3b3ee6b8d127" width="250" alt="old"> | <img src="https://github.com/user-attachments/assets/e0c42f6d-6b1f-457c-9c15-853d09d21dae" width="250" alt="new">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels