### PR TITLE
fix: renderoverflex error while requesting otp on some devices

### DIFF
--- a/lib/views/screens/email_verification_screen.dart
+++ b/lib/views/screens/email_verification_screen.dart
@@ -77,8 +77,11 @@ class EmailVerificationScreen extends StatelessWidget {
                   ],
                 ),
               ),
-              SizedBox(
-                height: UiSizes.height_60,
+              Expanded(
+                flex: 1,
+                child: SizedBox(
+                  height: UiSizes.height_60,
+                ),
               ),
               OtpTextField(
                 autoFocus: true,


### PR DESCRIPTION
## Description

This PR fixes an existing RenderOverFlex error found in some devices while requesting OTP for Email Verification

#### This was not an issue raised. The issue was found while testing and is directly fixed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested on a real Android 14.0.1 Redmi Note 10 Pro device. Below are the screenshots:

Old | New
--- | ---
<img src="https://github.com/user-attachments/assets/660feb8b-eaba-4cb5-a524-ee2d02536ffb" width="250" alt="old"> | <img src="https://github.com/user-attachments/assets/8063ca25-c834-4c0b-882b-7a36dbda9573" width="250" alt="new">
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Tag the PR with the appropriate labels