### PR TITLE
Fix incorrect IP address in ONBOARDING.md

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -104,6 +104,4 @@ You just need to update the baseDomain variable value in the constants.dart on c
 |---------------------|---------------|
 | Android Simulator   | `10.0.2.2`    |
 | iOS Simulator       | `127.0.0.1`   |
-| Physical Device     | Ensure laptop and phone are on the same Wi-Fi, then use the phone's IP address provided by the Wi-Fi |
-
-
+| Physical Device     | Ensure laptop and phone are on the same Wi-Fi, then use the laptop's IP address provided by the Wi-Fi |


### PR DESCRIPTION
Fixes #416

Update `ONBOARDING.md` to correct the IP address for debugging with a Physical Device.

* Modify the instructions under "Connecting Frontend and Backend" to use the laptop's IP address instead of the phone's IP address.
* Update the table under "Connecting Frontend and Backend" to list the Base Domain for a Physical Device as the laptop's IP address.

