### PR TITLE
Made floating action button icon change dynamically

### DIFF
--- a/lib/views/screens/tabview_screen.dart
+++ b/lib/views/screens/tabview_screen.dart
@@ -65,7 +65,7 @@ class TabViewScreen extends StatelessWidget {
           ),
           floatingActionButton: (controller.getIndex() == 0)
               ? SpeedDial(
-                  icon: Icons.add,
+                  icon: Icons.add_call,
                   childrenButtonSize: Size(UiSizes.width_56, UiSizes.height_56),
                   activeIcon: Icons.close,
                   elevation: 8.0,
@@ -137,7 +137,9 @@ class TabViewScreen extends StatelessWidget {
                     }
                   },
                   child: Icon(
-                      controller.getIndex() == 2 ? Icons.done : Icons.add,
+                      controller.getIndex() == 2
+                          ? Icons.done
+                          : Icons.audiotrack_rounded,
                       size: UiSizes.size_24)),
           floatingActionButtonLocation:
               FloatingActionButtonLocation.centerDocked,


### PR DESCRIPTION
## Description

The icon of the center docked Floating Action Button now changes dynamically for a better UX as previously the icon remained the same on both the Home Screen and Explore Screen despite the button performing different functions.

Fixes #452 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The App was run and the icon was verified to change appropriately as intended without causing unforeseen issues or breaking anything else.

<div align="center">
  <img src="https://github.com/user-attachments/assets/6fb330cb-20ad-451f-b9f5-237c446dec6d" width="45%"/>
  <img src="https://github.com/user-attachments/assets/ea9c96e3-c72f-4469-a414-d5c1032d3258" width="45%"/>
</div>

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #452 
- [ ] Tag the PR with the appropriate labels