### PR TITLE
Add tags for genres in explore screen

### DIFF
--- a/lib/utils/colors.dart
+++ b/lib/utils/colors.dart
@@ -18,4 +18,12 @@ class AppColor {
     Colors.amber,
     AppColor.yellowColor,
   ]);
+  static const Map<String, Color> categoryColorList = {
+    "drama": Color.fromARGB(255, 237, 29, 154),
+    "horror": Color.fromARGB(255, 21, 178, 136),
+    "comedy": Color.fromARGB(255, 142, 16, 238),
+    "thriller": Color.fromARGB(255, 38, 83, 215),
+    "romance": Color.fromARGB(255, 140, 204, 37),
+    "spiritual": Color.fromARGB(255, 218, 83, 83),
+  };
 }

--- a/lib/views/screens/explore_screen.dart
+++ b/lib/views/screens/explore_screen.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:loading_indicator/loading_indicator.dart';
 import 'package:resonate/controllers/explore_story_controller.dart';
 import 'package:resonate/utils/app_images.dart';
+import 'package:resonate/utils/colors.dart';
 import 'package:resonate/utils/debouncer.dart';
 import 'package:resonate/utils/enums/story_category.dart';
 import 'package:resonate/views/widgets/category_card.dart';
@@ -166,7 +167,8 @@ class ExplorePageContent extends StatelessWidget {
             itemBuilder: (context, index) {
               return CategoryCard(
                 name: StoryCategory.values[index].name,
-                color: categoryColorList[index],
+                color: AppColor.categoryColorList[
+                    StoryCategory.values[index].name.toLowerCase()]!,
                 exploreStoryController: exploreStoryController,
               );
             },
@@ -255,7 +257,6 @@ class ExplorePageContent extends StatelessWidget {
           height: 10,
         ),
         SizedBox(
-          height: 300,
           width: double.infinity,
           child: Obx(
             () => !exploreStoryController.isLoadingRecommendedStories.value
@@ -314,15 +315,6 @@ class ExplorePageContent extends StatelessWidget {
     );
   }
 }
-
-final List<Color> categoryColorList = [
-  const Color.fromARGB(255, 237, 29, 154),
-  const Color.fromARGB(255, 21, 178, 136),
-  const Color.fromARGB(255, 142, 16, 238),
-  const Color.fromARGB(255, 38, 83, 215),
-  const Color.fromARGB(255, 140, 204, 37),
-  const Color.fromARGB(255, 218, 83, 83),
-];
 
 class SearchResultContent extends StatelessWidget {
   const SearchResultContent({

--- a/lib/views/widgets/story_list_tile.dart
+++ b/lib/views/widgets/story_list_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get_utils/src/extensions/string_extensions.dart';
 import 'package:resonate/models/story.dart';
+import 'package:resonate/utils/colors.dart';
 import 'package:resonate/views/screens/story_screen.dart';
 
 class StoryListTile extends StatelessWidget {
@@ -27,15 +28,38 @@ class StoryListTile extends StatelessWidget {
               fontFamily: 'Inter',
             ),
       ),
-      subtitle: Text(
-        '${story.category.name.capitalizeFirst} - ${story.creatorName}',
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-        style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-              fontSize: 12,
-              fontStyle: FontStyle.normal,
-              fontFamily: 'Inter',
-            ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            story.creatorName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                  fontSize: 12,
+                  fontStyle: FontStyle.normal,
+                  fontFamily: 'Inter',
+                ),
+          ),
+          Container(
+              margin: const EdgeInsets.only(top: 5),
+              padding: const EdgeInsets.all(3),
+              decoration: BoxDecoration(
+                  color: AppColor
+                      .categoryColorList[story.category.name.toLowerCase()],
+                  borderRadius: BorderRadius.circular(10)),
+              child: Text(
+                story.category.name.capitalizeFirst ?? "",
+                maxLines: 1,
+                textAlign: TextAlign.left,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                    fontSize: 12,
+                    fontStyle: FontStyle.normal,
+                    fontFamily: 'Inter',
+                    fontWeight: FontWeight.bold),
+              )),
+        ],
       ),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
## Description

This PR adds a better representation for Story Genres in the List Tiles displaying stories within the Explore Screen Suggestions tab. 
Before: 
![image](https://github.com/user-attachments/assets/727fe359-8e94-4531-ba10-e4217ffd5d79)
After:
![image](https://github.com/user-attachments/assets/34e80090-66ee-4b01-9c8e-de2bed497d94)

Fixes #454 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
This was tested by adding different stories of different genres:
![image](https://github.com/user-attachments/assets/15825439-6e4f-4812-b414-a3689be95d14)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #454 
- [ ] Tag the PR with the appropriate labels