### PR TITLE
AGP Version changes and Pubspec fix

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace ="com.resonate.resonate"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
@@ -65,8 +65,7 @@ flutter {
 }
 
 dependencies {
-     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22")
-     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.0.9")
+     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.2")
      implementation("androidx.window:window:1.0.0")
      implementation("androidx.window:window-java:1.0.0")
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.1.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
+    id("com.android.application") version "8.11.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.20" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: '>=3.2.4 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -88,7 +88,9 @@ dependencies:
   url_launcher: ^6.1.12
   uuid: ^4.5.1
   audio_metadata_reader:
-    path: /Users/madhav/development/GitHub/audio_metadata_reader
+    git:
+      url: https://github.com/M4dhav/audio_metadata_reader.git
+      ref: main
   flutter_localizations:
     sdk: flutter
 


### PR DESCRIPTION
## Description

This PR makes changes to the AGP and Kotlin versions that Resonate uses to fix version mismatches and compatibility issues. Additionally, it fixes an issue introduced by #483 where a static path is used to reference the audio_metadata_reader dependency.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking CHANGE which fixes an issue)

## How Has This Been Tested?

App was compiled for release and compiled without issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] Tag the PR with the appropriate labels