### PR TITLE
fix: fixed workflow bug

### DIFF
--- a/.github/workflows/update-project-structure.yml
+++ b/.github/workflows/update-project-structure.yml
@@ -21,6 +21,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add project_structure.txt
-          git commit -m "chore: update project structure"
-          git push
+
+          if [[ -n $(git status --porcelain) ]]; then
+            git add project_structure.txt
+            git commit -m "chore: update project structure"
+            git push
+          else
+            echo "No changes to commit."
+          fi


### PR DESCRIPTION
## Description

To prevent the GitHub Actions workflow from failing when there are no changes to commit, I have modified the commit and push step to check if there are any changes before attempting to commit.

Fixes #498 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking CHANGE which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #498
- [x] Tag the PR with the appropriate labels