### PR TITLE
docs: add Google Play download link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
  </span>
 
 # :microphone: Resonate - An Open Source Social Voice Platform
+
 </div>
 <div align="center" style="text-align:center;"> 
 <span>
@@ -29,7 +30,6 @@
 <br>
 <br>
 
-
 <div align="center">
   
 [![License:GPL-3.0](https://img.shields.io/badge/License-GPL-yellow.svg)](https://opensource.org/license/gpl-3-0/)
@@ -37,10 +37,12 @@
 
 </div>
 
+With social voice platforms like Spotify, Clubhouse, and Twitter Spaces experiencing rapid growth, Resonate is here to harness the power of open-source for voice-based social media. **🚀 Resonate is now live and available for download on Google Play Store!** Whether it's sharing immersive stories, engaging in dynamic live discussions, or connecting through pair chats and voice calls, Resonate is designed to put voice at the center of your social experience. By fostering innovation and growth, this project aims to reach new heights, continually expanding its features and community, all while staying true to the open-source spirit of collaboration and transparency.
 
-With social voice platforms like Spotify, Clubhouse, and Twitter Spaces experiencing rapid growth, Resonate is here to harness the power of open-source for voice-based social media. Whether it's sharing immersive stories, engaging in dynamic live discussions, or connecting through pair chats and voice calls, Resonate is designed to put voice at the center of your social experience. By fostering innovation and growth, this project aims to reach new heights, continually expanding its features and community, all while staying true to the open-source spirit of collaboration and transparency.
+[![Get it on Google Play](https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png)](https://play.google.com/store/apps/details?id=com.resonate.resonate)
 
 ## :rocket: Features
+
 1. Real-time Audio Communication by joining rooms and talking to people.
 2. Ability to create rooms and moderate speakers and events.
 3. Create Scheduled Rooms and notify subscribers as reminders to join
@@ -52,38 +54,40 @@ With social voice platforms like Spotify, Clubhouse, and Twitter Spaces experien
 
 1.  **Flutter** - Mobile application
 2.  **Appwrite** - Authentication, Database, Storage and Cloud functions.
-3.  **LiveKit** - Web Real-Time Communication 
+3.  **LiveKit** - Web Real-Time Communication
 
 ## :link: Repository Links
+
 1. [Resonate Flutter App](https://github.com/AOSSIE-Org/Resonate)
 2. [Resonate Backend](https://github.com/AOSSIE-Org/Resonate-Backend)
 
-
 ## :four_leaf_clover: Getting Started
+
 Resonate is a wide project taking use of other software solutions like Appwrite and Livekit, starting up can be a little challenging
 
-We offer a guide for walking you through setting up the entire project, including a script that automates the set up of the backend environment for you. 
+We offer a guide for walking you through setting up the entire project, including a script that automates the set up of the backend environment for you.
 Please go through and strictly follow the [Onboarding Guide](https://github.com/Aarush-Acharya/Resonate/blob/master/ONBOARDING.md) for setting up the project for development and further contribution
 
 ## :movie_camera: App Screenshots
+
 <div align="center">
  
 | Login Screen (Forest) | Home Screen (Time) | Create Room Screen (Time) |
 | :---         |     :---      |          :--- |
 | <img src= "https://github.com/user-attachments/assets/e76147b1-0e51-4852-8198-06bbc975b25c" width="260" height="auto" />  | <img src="https://github.com/user-attachments/assets/ad62eecb-b621-4c31-a01c-001ff5462b28" width="250" height="auto" />    | <img src="https://github.com/user-attachments/assets/31ce6e73-8dca-4e2d-8f48-c22480fa1332" width="250" height="auto" />    |
 
-| Room Screen (Cream) | Profile Screen (Amber) | Explore Story (Forest) |
-| :---         |     :---      |          :--- |
-|  <img src="https://github.com/user-attachments/assets/f1d6e62f-5f25-47c1-9f59-e165d7018c0c" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/b9dfe363-79b1-4eee-8d00-28f5c14f93ee" width="250" height="auto" />   |  <img src="https://github.com/user-attachments/assets/c7657be8-bce2-4c3a-aee3-dd3cc33379a2" width="250" height="auto"/>    |
+| Room Screen (Cream)                                                                                                     | Profile Screen (Amber)                                                                                                  | Explore Story (Forest)                                                                                                 |
+| :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| <img src="https://github.com/user-attachments/assets/f1d6e62f-5f25-47c1-9f59-e165d7018c0c" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/b9dfe363-79b1-4eee-8d00-28f5c14f93ee" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/c7657be8-bce2-4c3a-aee3-dd3cc33379a2" width="250" height="auto"/> |
 
-| Explore Story (Amber) | Theme Screen (Vintage) | Upcoming Room Screen (Cream) |
-| :---         |     :---      |          :--- |
-|  <img src="https://github.com/user-attachments/assets/ba7da784-48a6-4512-a4c8-9f12b8ad13c1" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/ba9273f2-ceef-441d-8f94-4e0bc53b3e99" width="250" height="auto" />   |  <img src="https://github.com/user-attachments/assets/a46c7da4-2df4-4c62-9e4c-9c92102339e9" width="250" height="auto"/>    |
+| Explore Story (Amber)                                                                                                   | Theme Screen (Vintage)                                                                                                  | Upcoming Room Screen (Cream)                                                                                           |
+| :---------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- |
+| <img src="https://github.com/user-attachments/assets/ba7da784-48a6-4512-a4c8-9f12b8ad13c1" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/ba9273f2-ceef-441d-8f94-4e0bc53b3e99" width="250" height="auto" /> | <img src="https://github.com/user-attachments/assets/a46c7da4-2df4-4c62-9e4c-9c92102339e9" width="250" height="auto"/> |
+
 </div>
 
-
-
 ## :raised_hands: Contributing
+
 :star: Don't forget to star this repository if you find it useful! :star:
 
 Thank you for considering contributing to this project! Contributions are highly appreciated and welcomed (P.S. to the `dev` branch). To ensure a smooth collaboration, Refer to the [Contribution Guidelines](https://github.com/AOSSIE-Org/Resonate/blob/master/CONTRIBUTING.md).
@@ -94,17 +98,18 @@ By following these guidelines, we can maintain a productive and collaborative op
 
 ## :v: Maintainers
 
--   [Jaideep Prasad](https://github.com/jddeep)
--   [Chandan S Gowda](https://github.com/chandansgowda)
+- [Jaideep Prasad](https://github.com/jddeep)
+- [Chandan S Gowda](https://github.com/chandansgowda)
 
 ## :mailbox: Communication Channels
 
 If you have any questions, need clarifications, or want to discuss ideas, feel free to reach out through the following channels:
 
--   [Discord Server](https://discord.com/invite/6mFZ2S846n)
--   [Email](mailto:aossie.oss@gmail.com)
+- [Discord Server](https://discord.com/invite/6mFZ2S846n)
+- [Email](mailto:aossie.oss@gmail.com)
 
 <!-- License -->
+
 ## :round_pushpin: License
 
 Distributed under the [GNU General Public License](https://opensource.org/license/gpl-3-0/). See [LICENSE](https://github.com/AOSSIE-Org/Resonate/blob/master/LICENSE) for more information.
@@ -117,5 +122,3 @@ Thanks a lot for spending your time helping Resonate grow. Keep rocking 🥂
   <img src="https://contrib.rocks/image?repo=AOSSIE-Org/Resonate" alt="Contributors"/>
 </a>
 <br>
- 
-

--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@
   
 [![License:GPL-3.0](https://img.shields.io/badge/License-GPL-yellow.svg)](https://opensource.org/license/gpl-3-0/)
 ![GitHub Org's stars](https://img.shields.io/github/stars/AOSSIE-Org/Resonate?style=social)
+[![Get it on Google Play](https://img.shields.io/badge/Get_it_on-Google_Play-414141?style=flat&logo=google-play&logoColor=white)](https://play.google.com/store/apps/details?id=com.resonate.resonate)
 
 </div>
 
-With social voice platforms like Spotify, Clubhouse, and Twitter Spaces experiencing rapid growth, Resonate is here to harness the power of open-source for voice-based social media. **🚀 Resonate is now live and available for download on Google Play Store!** Whether it's sharing immersive stories, engaging in dynamic live discussions, or connecting through pair chats and voice calls, Resonate is designed to put voice at the center of your social experience. By fostering innovation and growth, this project aims to reach new heights, continually expanding its features and community, all while staying true to the open-source spirit of collaboration and transparency.
-
-[![Get it on Google Play](https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png)](https://play.google.com/store/apps/details?id=com.resonate.resonate)
+With social voice platforms like Spotify, Clubhouse, and Twitter Spaces experiencing rapid growth, Resonate is here to harness the power of open-source for voice-based social media. **The app is now live and available for download on Google Play Store!** Whether it's sharing immersive stories, engaging in dynamic live discussions, or connecting through pair chats and voice calls, Resonate is designed to put voice at the center of your social experience. By fostering innovation and growth, this project aims to reach new heights, continually expanding its features and community, all while staying true to the open-source spirit of collaboration and transparency.
 
 ## :rocket: Features
 


### PR DESCRIPTION
## Description
Added Google Play Store download link to README based on maintainer feedback. Integrated the announcement naturally into existing content without creating a separate section.

Fixes: #517 

## Type of change
- [x] Documentation update

## Changes Made
- Added download announcement to the main description paragraph
- Included small Google Play badge below existing repository badges
- Used GitHub Flavored Markdown (no HTML/CSS) for better compatibility
- Kept minimal space usage as requested

## Preview
<img width="458" height="78" alt="image" src="https://github.com/user-attachments/assets/886fa34f-dd6f-4f34-9362-62a7141919ac" />

## Checklist:
- [x] Follows project style guidelines
- [x] Used GitHub Flavored Markdown only
- [x] Verified download link works correctly
- [x] Self-reviewed changes
- [x] No spelling errors