### PR TITLE
chore: Bump app version to 2.0.0+1 for v2 release

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+4
+version: 2.0.0+1
 
 environment:
   sdk: ">=3.9.0 <4.0.0"


### PR DESCRIPTION
## Description
This PR Bumps the version of the app in Pubspec to 2.0.0 for v2 release in the play store
Fixes #533 

## Type of change

Please delete options that are not relevant.

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?
Not relevant

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #533
- [x] Tag the PR with the appropriate labels