### PR TITLE
Fix/livekit async init error handling

### DIFF
--- a/lib/controllers/friend_calling_controller.dart
+++ b/lib/controllers/friend_calling_controller.dart
@@ -245,7 +245,7 @@ class FriendCallingController extends GetxController {
   void toggleMic() async {
     isMicOn.value = !isMicOn.value;
     if (!Get.testMode) {
-      await Get.find<LiveKitController>().liveKitRoom.localParticipant
+      await Get.find<LiveKitController>().liveKitRoom?.localParticipant
           ?.setMicrophoneEnabled(isMicOn.value);
     }
   }

--- a/lib/controllers/live_chapter_controller.dart
+++ b/lib/controllers/live_chapter_controller.dart
@@ -192,13 +192,13 @@ class LiveChapterController extends GetxController {
   }
 
   Future<void> turnOnMic() async {
-    await Get.find<LiveKitController>().liveKitRoom.localParticipant
+    await Get.find<LiveKitController>().liveKitRoom?.localParticipant
         ?.setMicrophoneEnabled(true);
     isMicOn.value = true;
   }
 
   Future<void> turnOffMic() async {
-    await Get.find<LiveKitController>().liveKitRoom.localParticipant
+    await Get.find<LiveKitController>().liveKitRoom?.localParticipant
         ?.setMicrophoneEnabled(false);
     isMicOn.value = false;
   }

--- a/lib/controllers/pair_chat_controller.dart
+++ b/lib/controllers/pair_chat_controller.dart
@@ -251,7 +251,7 @@ class PairChatController extends GetxController {
 
   void toggleMic() async {
     isMicOn.value = !isMicOn.value;
-    await Get.find<LiveKitController>().liveKitRoom.localParticipant
+    await Get.find<LiveKitController>().liveKitRoom?.localParticipant
         ?.setMicrophoneEnabled(isMicOn.value);
   }
 

--- a/lib/controllers/single_room_controller.dart
+++ b/lib/controllers/single_room_controller.dart
@@ -260,14 +260,14 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> turnOnMic() async {
-    await Get.find<LiveKitController>().liveKitRoom.localParticipant
+    await Get.find<LiveKitController>().liveKitRoom?.localParticipant
         ?.setMicrophoneEnabled(true);
     await updateParticipantDoc(appwriteRoom.myDocId!, {"isMicOn": true});
     me.value.isMicOn = true;
   }
 
   Future<void> turnOffMic() async {
-    await Get.find<LiveKitController>().liveKitRoom.localParticipant
+    await Get.find<LiveKitController>().liveKitRoom?.localParticipant
         ?.setMicrophoneEnabled(false);
     await updateParticipantDoc(appwriteRoom.myDocId!, {"isMicOn": false});
     me.value.isMicOn = false;

--- a/test/controllers/livekit_controller_test.dart
+++ b/test/controllers/livekit_controller_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:resonate/controllers/livekit_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LiveKitController Tests', () {
+    late LiveKitController controller;
+    const String testUri = 'ws://test.livekit.com';
+    const String testToken = 'test-token';
+
+    setUp(() {
+      Get.testMode = true;
+    });
+
+    tearDown(() {
+      Get.reset();
+    });
+
+    test('onInit should be synchronous and not crash', () {
+      controller = LiveKitController(
+        liveKitUri: testUri,
+        roomToken: testToken,
+      );
+
+      // onInit should complete immediately without throwing
+      expect(() => controller.onInit(), returnsNormally);
+
+      // Initial state should be disconnected
+      expect(controller.isConnected.value, false);
+      expect(controller.reconnectAttempts, 0);
+    });
+
+    test('liveKitRoom should be nullable', () {
+      controller = LiveKitController(
+        liveKitUri: testUri,
+        roomToken: testToken,
+      );
+
+      // liveKitRoom should be null before connection
+      expect(controller.liveKitRoom, isNull);
+      expect(controller.listener, isNull);
+    });
+
+    test('onClose should handle null resources gracefully', () async {
+      controller = LiveKitController(
+        liveKitUri: testUri,
+        roomToken: testToken,
+      );
+
+      // Should not crash even if liveKitRoom is null
+      expect(() async => await controller.onClose(), returnsNormally);
+    });
+
+    test('isRecording should default to false', () {
+      controller = LiveKitController(
+        liveKitUri: testUri,
+        roomToken: testToken,
+        isLiveChapter: true,
+      );
+
+      expect(controller.isRecording.value, false);
+    });
+
+    test('reconnectAttempts should initialize to 0', () {
+      controller = LiveKitController(
+        liveKitUri: testUri,
+        roomToken: testToken,
+      );
+
+      expect(controller.reconnectAttempts, 0);
+    });
+  });
+}


### PR DESCRIPTION
Description:
**Closes #613**

## 🐛 Bug Fix

Fixes critical bug where `LiveKitController` crashes with `LateInitializationError` when connection fails due to poor network.

## 🔍 Problem
- `onInit()` was `async void` - cannot catch errors properly
- `liveKitRoom` accessed before initialization completes
- No user feedback on connection failures
- App crashes instead of handling gracefully

## ✅ Solution
- Changed `onInit()` to synchronous (proper GetX lifecycle)
- Made `liveKitRoom` and `listener` nullable
- Added try-catch with user-friendly error messages
- Updated 4 dependent controllers for null safety
- Added unit tests for null safety validation

## 📝 Files Changed
- `lib/controllers/livekit_controller.dart` - Main fix
- `lib/controllers/pair_chat_controller.dart` - Null safety
- `lib/controllers/single_room_controller.dart` - Null safety
- `lib/controllers/live_chapter_controller.dart` - Null safety
- `lib/controllers/friend_calling_controller.dart` - Null safety
- `test/controllers/livekit_controller_test.dart` - Unit tests

## 🧪 Testing
Added 5 unit tests covering:
- Synchronous onInit() lifecycle
- Null safety for liveKitRoom and listener
- Graceful cleanup in onClose()
- Initial state validation

## 🚀 Impact
- ✅ No more crashes on poor network
- ✅ Better UX with error messages
- ✅ Follows GetX best practices
- ✅ Backward compatible
