### PR TITLE
Fix: Critical Appwrite v1.8 Relationship Bug (Issue #636) , This issue is solved during Unstoppable Hackathon Period

### DIFF
--- a/lib/controllers/change_email_controller.dart
+++ b/lib/controllers/change_email_controller.dart
@@ -40,7 +40,6 @@ class ChangeEmailController extends GetxController {
       collectionId: usernameCollectionID,
       queries: [
         Query.equal('email', changedEmail),
-        // FIX: Added Query.select(['*']) to ensure all fields/relationships are returned
         Query.select(['*']), 
       ],
     );
@@ -57,7 +56,6 @@ class ChangeEmailController extends GetxController {
     BuildContext context,
   ) async {
     try {
-      // change in user info collection
       await databases.updateDocument(
         databaseId: userDatabaseID,
         collectionId: usersCollectionID,
@@ -65,7 +63,6 @@ class ChangeEmailController extends GetxController {
         data: {'email': changedEmail},
       );
 
-      // change in username - email collection
       await databases.updateDocument(
         databaseId: userDatabaseID,
         collectionId: usernameCollectionID,
@@ -73,7 +70,6 @@ class ChangeEmailController extends GetxController {
         data: {'email': changedEmail},
       );
 
-      // Set user profile in authStateController
       await authStateController.setUserProfileData();
 
       return true;
@@ -100,7 +96,6 @@ class ChangeEmailController extends GetxController {
     BuildContext context,
   ) async {
     try {
-      // change in auth section
       await account.updateEmail(email: changedEmail, password: password);
 
       return true;

--- a/lib/controllers/pair_chat_controller.dart
+++ b/lib/controllers/pair_chat_controller.dart
@@ -43,8 +43,6 @@ class PairChatController extends GetxController {
   void quickMatch() async {
     String uid = authController.uid!;
     String userName = authController.userName!;
-
-    // Open realtime stream to check whether the request is paired
     getRealtimeStream();
 
     Map<String, dynamic> requestData = {
@@ -54,8 +52,6 @@ class PairChatController extends GetxController {
       "isRandom": true,
     };
     requestData.addIf(!isAnonymous.value, "userName", userName);
-
-    // Add request to pair-request collection
     Document requestDoc = await databases.createDocument(
       databaseId: masterDatabaseId,
       collectionId: pairRequestCollectionId,
@@ -63,8 +59,6 @@ class PairChatController extends GetxController {
       data: requestData,
     );
     requestDocId = requestDoc.$id;
-
-    // Go to pairing screen
     Get.toNamed(AppRoutes.pairing);
   }
 
@@ -82,8 +76,6 @@ class PairChatController extends GetxController {
       "name": authController.displayName,
       "userRating": authController.ratingTotal / authController.ratingCount,
     };
-
-    // Add request to pair-request collection
     Document requestDoc = await databases.createDocument(
       databaseId: masterDatabaseId,
       collectionId: pairRequestCollectionId,
@@ -115,8 +107,6 @@ class PairChatController extends GetxController {
       if (data.payload.isNotEmpty) {
         String uid1 = data.payload["uid1"];
         String uid2 = data.payload["uid2"];
-
-        // If the request was served and the user was paired
         if (uid1 == uid || uid2 == uid) {
           log(data.toString());
           var docId = data.payload["\$id"].toString();
@@ -186,12 +176,11 @@ class PairChatController extends GetxController {
       if (data.payload.isNotEmpty) {
         if (event.endsWith('.create')) {
           log('adding new user');
-          // If a new user is added to the pair request collection
           final userData = data.payload;
           final eventSplit = event.split('.');
           final docId =
-              eventSplit[eventSplit.length - 2]; // Get the second last
-          userData['docId'] = docId; // Add docId to the user
+              eventSplit[eventSplit.length - 2]; 
+          userData['docId'] = docId; 
           ResonateUser newUser = ResonateUser.fromJson(userData);
 
           usersList.add(newUser);
@@ -214,7 +203,6 @@ class PairChatController extends GetxController {
         Query.notEqual('uid', authController.uid!),
         Query.notEqual('isAnonymous', true),
         Query.limit(100),
-        // FIX: Added this line to fetch all relationship fields
         Query.select(['*']), 
       ],
     );
@@ -225,7 +213,7 @@ class PairChatController extends GetxController {
       usersList.addAll(
         result.documents.map((doc) {
           final userData = doc.data;
-          userData['docId'] = doc.$id; // Add docId to the user data
+          userData['docId'] = doc.$id; 
           ResonateUser user = ResonateUser.fromJson(userData);
 
           return user;

--- a/lib/controllers/room_chat_controller.dart
+++ b/lib/controllers/room_chat_controller.dart
@@ -50,7 +50,6 @@ class RoomChatController extends GetxController {
       Query.equal('roomId', appwriteRoom?.id ?? appwriteUpcommingRoom!.id),
       Query.orderAsc('index'),
       Query.limit(100),
-      // FIX: Added this line to fetch all fields including relationships
       Query.select(['*']),
     ];
     ReplyTo? replyTo;
@@ -69,10 +68,9 @@ class RoomChatController extends GetxController {
         replyTo = ReplyTo.fromJson(replyToDoc.data);
       } catch (e) {
         if (e is AppwriteException && e.code == 404) {
-          // If replyTo document not found, set it to null
           replyTo = null;
         } else {
-          rethrow; // Rethrow if it's a different error
+          rethrow; 
         }
       }
       messages.add(
@@ -134,7 +132,6 @@ class RoomChatController extends GetxController {
       }
       message.replyTo = replyingTo.value;
 
-      // messages.add(message);
       replyingTo.value = null;
     } catch (e) {
       log('Error sending message: $e');
@@ -222,11 +219,10 @@ class RoomChatController extends GetxController {
                 replyTo = ReplyTo.fromJson(replyToDoc.data);
               } catch (e) {
                 if (e is AppwriteException && e.code == 404) {
-                  // If replyTo document not found, set it to null
                   replyTo = null;
                 } else {
                   log("Error fetching replyTo document: ${e.toString()}");
-                  rethrow; // Rethrow if it's a different error
+                  rethrow; 
                 }
               }
               newMessage.replyTo = replyTo;

--- a/lib/controllers/rooms_controller.dart
+++ b/lib/controllers/rooms_controller.dart
@@ -36,14 +36,12 @@ class RoomsController extends GetxController {
   }
 
   Future<AppwriteRoom> createRoomObject(Document room, String userUid) async {
-    // Get three particpant data to use for memberAvatar widget
     var participantCollectionRef = await databases.listDocuments(
       databaseId: masterDatabaseId,
       collectionId: participantsCollectionId,
       queries: [
         Query.equal("roomId", room.data["\$id"]),
         Query.limit(3),
-        // FIX: Added to ensure participant relationships are fetched
         Query.select(['*']),
       ],
     );
@@ -57,7 +55,6 @@ class RoomsController extends GetxController {
       memberAvatarUrls.add(participantDoc.data["profileImageUrl"]);
     }
 
-    // Create appwrite room object and add it to rooms list
     AppwriteRoom appwriteRoom = AppwriteRoom(
       id: room.data['\$id'],
       name: room.data["name"],
@@ -77,13 +74,10 @@ class RoomsController extends GetxController {
     try {
       isLoading.value = true;
       String userUid = Get.find<AuthStateController>().uid!;
-
-      // Get active rooms and add it to rooms list
       rooms.value = [];
       var roomsCollectionRef = await databases.listDocuments(
         databaseId: masterDatabaseId,
         collectionId: roomsCollectionId,
-        // FIX: Added to ensure room data is complete
         queries: [Query.select(['*'])],
       );
 
@@ -133,7 +127,6 @@ class RoomsController extends GetxController {
         name: AppLocalizations.of(Get.context!)!.loadingDialog,
       );
 
-      // Get the token and livekit url and join livekit room
       AuthStateController authStateController = Get.find<AuthStateController>();
       String myDocId = await RoomService.joinRoom(
         roomId: room.id,
@@ -142,15 +135,12 @@ class RoomsController extends GetxController {
       );
       room.myDocId = myDocId;
 
-      // Close the loading dialog
       Get.back();
-      // Open the Room Bottom Sheet to interact in the room
       Get.find<TabViewController>().openRoomSheet(room);
     } catch (e) {
       log(e.toString());
       getRooms();
       update();
-      // Close the loading dialog
       Get.back();
     }
   }

--- a/lib/controllers/single_room_controller.dart
+++ b/lib/controllers/single_room_controller.dart
@@ -120,7 +120,6 @@ class SingleRoomController extends GetxController {
         collectionId: participantsCollectionId,
         queries: [
           Query.equal('roomId', appwriteRoom.id),
-          // FIX: Added to ensure participant data is loaded correctly
           Query.select(['*']),
         ],
       );
@@ -143,7 +142,6 @@ class SingleRoomController extends GetxController {
       if (data.payload.isNotEmpty) {
         String roomId = data.payload["roomId"];
         if (roomId == appwriteRoom.id) {
-          // This event belongs to the room current user is part of
           String updatedUserId = data.payload["uid"];
           String docId = data.payload["\$id"];
           String action = data.events.first.substring(
@@ -159,7 +157,6 @@ class SingleRoomController extends GetxController {
               }
             case 'update':
               {
-                // if the change is related to the current user
                 if (updatedUserId == me.value.uid) {
                   me.value.isModerator = data.payload["isModerator"];
                   me.value.hasRequestedToBeSpeaker =
@@ -194,15 +191,11 @@ class SingleRoomController extends GetxController {
 
   void sortParticipants() {
     participants.sort((a, b) {
-      // Sort by isAdmin (admins first, then non-admins)
       if (b.value.isAdmin && !a.value.isAdmin) return 1;
       if (!b.value.isAdmin && a.value.isAdmin) return -1;
-
-      // If isAdmin is the same, sort by isModerator (moderators first, then non-moderators)
       if (b.value.isModerator && !a.value.isModerator) return 1;
       if (!b.value.isModerator && a.value.isModerator) return -1;
 
-      // Continue sorting by isSpeaker, hasRequestedToBeSpeaker (true first, then false)
       if (b.value.isSpeaker && !a.value.isSpeaker) return 1;
       if (!b.value.isSpeaker && a.value.isSpeaker) return -1;
 
@@ -213,7 +206,7 @@ class SingleRoomController extends GetxController {
         return -1;
       }
 
-      return 0; // If all properties are equal (or if Listener), maintain the current order.
+      return 0;
     });
   }
 
@@ -246,7 +239,6 @@ class SingleRoomController extends GetxController {
       queries: [
         Query.equal('roomId', appwriteRoom.id),
         Query.equal('uid', participant.uid),
-        // FIX: Added to ensure we get the document ID correctly
         Query.select(['*']),
       ],
     );


### PR DESCRIPTION
Changes: Added Query.select(['*']) to the databases.listDocuments function in 5 controller files (change_email, pair_chat, room_chat, rooms, and single_room).

Reason: This fixes the Appwrite v1.8 breaking change where relationship fields (like user details inside a message) were returning null. The wildcard selector forces the API to fetch all nested data again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data retrieval across messaging, user lists, room and participant views so full details load reliably.
  * More robust email availability checks during verification flows.

* **Chores**
  * Codebase cleanup: removed stray inline comments and minor formatting tweaks for maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->