### PR TITLE
 Add Copy Link button to Room Screen [unstoppable Hackathon]

### DIFF
--- a/lib/views/screens/room_screen.dart
+++ b/lib/views/screens/room_screen.dart
@@ -69,7 +69,7 @@ class RoomScreenState extends State<RoomScreen> {
               const RoomAppBar(),
               Positioned(
                 right: 16,
-                top: 40, 
+                 
                 child: Row(
                   children: [
                     IconButton(
@@ -110,7 +110,7 @@ class RoomScreenState extends State<RoomScreen> {
               ),
             ],
           ),
-          // ------------------------------------------------
+
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: RoomHeader(


### PR DESCRIPTION
## Description
**The Feature:** Added a "Copy Link" button next to the Share button in the Room Screen.
**Motivation:** Completes the sharing functionality requested in the "Unstoppable Hackathon Tasks". Users can now quickly copy the direct room URL to their clipboard for manual sharing in other apps.

**Implementation:**
- Imported `flutter/services.dart` for Clipboard access.
- Refactored the header `Stack` to use a `Row`, placing the Copy and Share buttons side-by-side.
- Added logic to copy the room URL (`https://resonate.social/room/{id}`) to the clipboard.
- Added a `SnackBar` to provide visual feedback ("Room Link Copied!") to the user.

Fixes #xxxx

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Manually tested on Android emulator.
- Verified that clicking the "Copy" icon shows the "Room Link Copied!" SnackBar.
- Verified that the correct URL is pasted when using the system paste function.
- Verified that the "Share" button still functions correctly.

## Maintainer Checklist
-Close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy button on the room screen (overlay at top-right) that copies the room URL to the clipboard and shows a confirmation notification.
  * Added a Share button on the room screen (overlay at top-right) that lets users share the room name and link via the device’s sharing options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->