### PR TITLE
Updated live_room_tile with copy link next to share link

### DIFF
--- a/lib/views/widgets/live_room_tile.dart
+++ b/lib/views/widgets/live_room_tile.dart
@@ -149,7 +149,7 @@ class CustomLiveRoomTile extends StatelessWidget {
               maxLines: 3,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                
+                  color: Theme.of(context) 
                     .colorScheme
                     .onSurface
                     .withOpacity(0.7),


### PR DESCRIPTION
The room name Text widget is now wrapped in an Expanded widget to ensure proper truncation (TextOverflow.ellipsis) and prevent layout overflows when placed next to the two action buttons (Copy Link and Share).

The action buttons (Copy Link and Share) are grouped in a nested Row(mainAxisSize: MainAxisSize.min) for clean alignment on the right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy Link button to quickly copy room URLs to the clipboard with localized success and error messages.

* **UI/UX Improvements**
  * Prevented room name overflow and reorganized controls so Copy Link appears alongside Share while preserving Join; refined button tooltips and text contrast.

* **Bug Fixes**
  * Improved feedback handling with localized SnackBars, context checks, and graceful error handling for copy failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->