### PR TITLE
docs: clarify windows backend setup and branch usage

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -12,6 +12,19 @@ Please strictly stick to the guide do not go off installing stuff on your own
 
 - Docker
 
+### Windows note (Backend setup)
+
+When setting up the backend on Windows, make sure you are using the
+correct backend branch (`dev`) as the setup scripts differ between
+branches.
+
+Although the backend uses Appwrite CLI, on Windows the resolved
+`appwrite` binary can depend on PATH precedence (e.g. Scoop/Bun vs npm).
+If you face unexpected CLI errors, using the Node-based CLI via:
+
+npx appwrite-cli
+
+can help avoid runtime ambiguity.
 
 ### Installing Appwrite and Appwrite CLI 
 


### PR DESCRIPTION
This PR improves onboarding clarity for Windows contributors by:

- Explicitly mentioning the required backend branch
- Adding a note about Appwrite CLI resolution on Windows and how to
  avoid runtime ambiguity

This helps prevent setup confusion during backend initialization.

Resolves #700


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific setup instructions for backend configuration, including guidance on using the correct development branch and resolving Appwrite CLI path issues on Windows systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->