### PR TITLE
fix: livekit publisher error on reconnection attempts

### DIFF
--- a/lib/controllers/livekit_controller.dart
+++ b/lib/controllers/livekit_controller.dart
@@ -31,9 +31,13 @@ class LiveKitController extends GetxController {
   });
 
   @override
-  void onInit() async {
+  void onInit() {
     super.onInit();
-    await connectToRoom(); // Initial connection with retries
+    _initializeConnection();
+  }
+
+  Future<void> _initializeConnection() async {
+    await connectToRoom();
     if (isConnected.value) {
       liveKitRoom.addListener(onRoomDidUpdate);
       setUpListeners();
@@ -74,9 +78,10 @@ class LiveKitController extends GetxController {
     super.onClose();
   }
 
-  Future<bool> connectToRoom() async {
-    reconnectAttempts = 0;
-
+  Future<bool> connectToRoom({bool isReconnect = false}) async {
+    if (!isReconnect) {
+      reconnectAttempts = 0;
+    }
     while (reconnectAttempts < maxAttempts) {
       try {
         liveKitRoom = Room(

--- a/lib/controllers/livekit_controller.dart
+++ b/lib/controllers/livekit_controller.dart
@@ -146,7 +146,7 @@ class LiveKitController extends GetxController {
 
       reconnectTimer?.cancel();
       reconnectTimer = Timer(retryInterval, () async {
-        final success = await connectToRoom();
+        final success = await connectToRoom(isReconnect: true);
 
         if (!success && reconnectAttempts < maxAttempts) {
           await handleDisconnection();

--- a/lib/controllers/livekit_controller.dart
+++ b/lib/controllers/livekit_controller.dart
@@ -83,14 +83,16 @@ class LiveKitController extends GetxController {
       reconnectAttempts = 0;
     }
     while (reconnectAttempts < maxAttempts) {
+      Room? room;
       try {
-        liveKitRoom = Room(
+        room = Room(
           roomOptions: const RoomOptions(
             dynacast: false,
             adaptiveStream: false,
             defaultVideoPublishOptions: VideoPublishOptions(simulcast: false),
           ),
         );
+        liveKitRoom = room;
         listener = liveKitRoom.createListener();
 
         await liveKitRoom.connect(
@@ -111,24 +113,26 @@ class LiveKitController extends GetxController {
           'Connection attempt $reconnectAttempts/$maxAttempts failed: $error',
         );
         //cleaning up failed connection so multiple room  instances doesnt accumulate
-        try {
-          await liveKitRoom.disconnect();
-          await liveKitRoom.dispose();
-        } catch (e) {
-          log('Error cleaning up failed connection: $e');
-        }
+        if (room != null) {
+          try {
+            await room.disconnect();
+            await room.dispose();
+          } catch (e) {
+            log('Error cleaning up failed connection: $e');
+          }
 
-        if (reconnectAttempts < maxAttempts) {
-          await Future.delayed(retryInterval); // Wait before retrying
-        } else {
-          log('Failed to connect after $maxAttempts attempts');
-          isConnected.value = false; //changed the connection value to false
-          Get.snackbar(
-            AppLocalizations.of(Get.context!)!.connectionFailed,
-            AppLocalizations.of(Get.context!)!.unableToJoinRoom,
-            duration: const Duration(seconds: 5),
-          );
-          return false;
+          if (reconnectAttempts < maxAttempts) {
+            await Future.delayed(retryInterval); // Wait before retrying
+          } else {
+            log('Failed to connect after $maxAttempts attempts');
+            isConnected.value = false; //changed the connection value to false
+            Get.snackbar(
+              AppLocalizations.of(Get.context!)!.connectionFailed,
+              AppLocalizations.of(Get.context!)!.unableToJoinRoom,
+              duration: const Duration(seconds: 5),
+            );
+            return false;
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Fixed a critical bug where the LiveKit WebRTC publisher was being accessed before it was fully initialized, 
causing `E/flutter ( 7621): [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: LiveKit Exception: [UnexpectedConnectionState] publisher is closed
E/flutter ( 7621): #0      EngineInternalMethods.createTransceiverRTCRtpSender (package:livekit_client/src/core/engine.dart:1255:7)
engine.dart:1255
E/flutter ( 7621): #1      LocalParticipant.publishAudioTrack.negotiate (package:livekit_client/src/participant/local.dart:127:45)
local.dart:127
E/flutter ( 7621): #2      LocalParticipant.publishAudioTrack (package:livekit_client/src/participant/local.dart:134:87)
local.dart:134
E/flutter ( 7621): #3      LocalParticipant.setSourceEnabled (package:livekit_client/src/participant/local.dart:701:22)
local.dart:701
E/flutter ( 7621): <asynchronous suspension>
E/flutter ( 7621): #4      SingleRoomController.turnOnMic (package:resonate/controllers/single_room_controller.dart:263:5)
single_room_controller.dart:263
E/flutter ( 7621): <asynchronous suspension>`

Fixes #676 
after fixing the livekit controller file 

https://github.com/user-attachments/assets/5d60558e-7f59-4ab6-bfa0-c5985c225b17



## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking CHANGE which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Test Environment:

Device: Android x64emulator pixel 6 

Please include screenshots below if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #676 
- [x] Tag the PR with the appropriate labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability by adding a delay for stabilization after successful connection.
  * Enhanced error recovery with automatic cleanup of failed connection attempts.
  * Added user notification when connection fails after maximum retry attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->