### PR TITLE
Fix #612: Prevent multiple signup API calls by adding loading guard a…

### DIFF
--- a/lib/controllers/authentication_controller.dart
+++ b/lib/controllers/authentication_controller.dart
@@ -67,6 +67,8 @@ class AuthenticationController extends GetxController {
   }
 
   Future<bool> signup(BuildContext context) async {
+    if (isLoading.value) return false;
+
     try {
       isLoading.value = true;
       await authStateController.signup(

--- a/lib/views/screens/signup_screen.dart
+++ b/lib/views/screens/signup_screen.dart
@@ -230,15 +230,16 @@ class _SignupScreenState extends State<SignupScreen> {
                       ),
                     ),
                     SizedBox(height: UiSizes.height_10),
-                    SizedBox(
-                      width: double.maxFinite,
-                      child: ElevatedButton(
-                        onPressed: emailVerifyController.signUpIsAllowed.value
-                            ? () async {
+                      Obx(
+                        () => SizedBox(
+                          width: double.maxFinite,
+                          child: ElevatedButton(
+
+                            onPressed: controller.isLoading.value
+                              ? null
+                              : () async {
                                 if (controller.registrationFormKey.currentState!
                                     .validate()) {
-                                  emailVerifyController.signUpIsAllowed.value =
-                                      false;
                                   var isSignedIn = await controller.signup(
                                     context,
                                   );


### PR DESCRIPTION
Fixes an issue where multiple rapid taps on the Sign Up button triggered duplicate API calls.

Changes:

Added a guard in signup() to prevent parallel requests:

if (isLoading.value) return false;


Disabled the Sign Up button while the request is in progress.
Showed a loading indicator during processing.
This ensures duplicate signup requests cannot occur even if the button is tapped multiple times rapidly.

Fixes #612 

Type of change
 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
Navigated to Sign Up screen.

Rapidly tapped the Sign Up button.
Verified only one request is processed and the button is disabled during loading.

Checklist:
 Self-reviewed code
 No new warnings introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate signup form submissions by disabling the signup button while processing is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->