### PR TITLE
fix: prevent multiple room creation requests on rapid taps

### DIFF
--- a/lib/controllers/create_room_controller.dart
+++ b/lib/controllers/create_room_controller.dart
@@ -45,6 +45,8 @@ class CreateRoomController extends GetxController {
     List<String> tags,
     bool fromCreateScreen,
   ) async {
+    if (isLoading.value) return;
+
     if (fromCreateScreen) {
       if (!createRoomFormKey.currentState!.validate()) {
         return;


### PR DESCRIPTION
This PR prevents multiple room creation requests from being triggered when a user taps the "Create Room" button rapidly.

The createRoom() method in CreateRoomController did not previously guard against repeated invocations while an async request was already in progress. This could potentially lead to duplicate backend calls and unintended room creation.

A simple defensive guard has been added at the start of the method to ignore additional taps while isLoading is true.

Fixes #756

Type of change

 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?

This change was validated through static code analysis. The guard ensures that when isLoading is already true, additional calls to createRoom() return immediately, preventing concurrent backend requests.

No functional behavior was altered beyond preventing duplicate execution.

Checklist:

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 My changes generate no new warnings
 I have checked my code and corrected any misspellings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate room creation requests by ignoring subsequent attempts while an operation is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->