### PR TITLE
Refactor ApiService: centralize execution, add timeout and defensive …

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -6,33 +6,25 @@ import 'package:resonate/services/appwrite_service.dart';
 import 'package:resonate/utils/constants.dart';
 
 class ApiService {
-  static const _functionTimeoutDuration = Duration(seconds: 30);
-  
-  final Functions _functions = Functions(AppwriteService.getClient());
+  static const Duration _functionTimeoutDuration =
+      Duration(seconds: 30);
 
-  /// Executes an Appwrite function and safely parses the response.
+  final Functions _functions =
+      Functions(AppwriteService.getClient());
+
   Future<Map<String, dynamic>> _executeFunction({
     required String functionId,
     required Map<String, dynamic> payload,
   }) async {
+    late final Execution response;
+
     try {
-      final response = await _functions
+      response = await _functions
           .createExecution(
             functionId: functionId,
             body: jsonEncode(payload),
           )
           .timeout(_functionTimeoutDuration);
-
-      final int statusCode = response.responseStatusCode;
-      final String responseBody = response.responseBody;
-
-      if (statusCode != 200) {
-        throw Exception(
-          'Appwrite function failed (status: $statusCode): $responseBody',
-        );
-      }
-
-      return _decodeResponse(responseBody);
     } on TimeoutException {
       throw Exception(
         'Appwrite function timed out after ${_functionTimeoutDuration.inSeconds} seconds.',
@@ -41,14 +33,20 @@ class ApiService {
       throw Exception(
         'AppwriteException: ${e.message ?? 'Unknown Appwrite error'}',
       );
-    } catch (e) {
+    }
+
+    final int statusCode = response.responseStatusCode;
+    final String responseBody = response.responseBody;
+
+    if (statusCode != 200) {
       throw Exception(
-        'Unexpected error during function execution: $e',
+        'Appwrite function failed (status: $statusCode): $responseBody',
       );
     }
+
+    return _decodeResponse(responseBody);
   }
 
-  /// Safely decodes JSON and guarantees a Map<String, dynamic>.
   Map<String, dynamic> _decodeResponse(String body) {
     if (body.isEmpty) {
       throw Exception(
@@ -56,25 +54,23 @@ class ApiService {
       );
     }
 
+    final Object? decoded;
+
     try {
-      final Object? decoded = jsonDecode(body);
-
-      if (decoded is! Map) {
-        throw Exception(
-          'Unexpected response format: expected JSON object.',
-        );
-      }
-
-      return Map<String, dynamic>.from(decoded);
+      decoded = jsonDecode(body);
     } on FormatException {
       throw Exception(
         'Invalid JSON response from Appwrite function.',
       );
-    } catch (e) {
+    }
+
+    if (decoded is! Map) {
       throw Exception(
-        'Failed to parse response: $e',
+        'Unexpected response format: expected JSON object.',
       );
     }
+
+    return Map<String, dynamic>.from(decoded);
   }
 
   Future<Map<String, dynamic>> createRoom(

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,164 +1,148 @@
+import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
 
 import 'package:appwrite/appwrite.dart';
 import 'package:resonate/services/appwrite_service.dart';
 import 'package:resonate/utils/constants.dart';
 
 class ApiService {
-  final Functions functions = Functions(AppwriteService.getClient());
+  static const _functionTimeoutDuration = Duration(seconds: 30);
+  
+  final Functions _functions = Functions(AppwriteService.getClient());
+
+  /// Executes an Appwrite function and safely parses the response.
+  Future<Map<String, dynamic>> _executeFunction({
+    required String functionId,
+    required Map<String, dynamic> payload,
+  }) async {
+    try {
+      final response = await _functions
+          .createExecution(
+            functionId: functionId,
+            body: jsonEncode(payload),
+          )
+          .timeout(_functionTimeoutDuration);
+
+      final int statusCode = response.responseStatusCode;
+      final String responseBody = response.responseBody;
+
+      if (statusCode != 200) {
+        throw Exception(
+          'Appwrite function failed (status: $statusCode): $responseBody',
+        );
+      }
+
+      return _decodeResponse(responseBody);
+    } on TimeoutException {
+      throw Exception(
+        'Appwrite function timed out after ${_functionTimeoutDuration.inSeconds} seconds.',
+      );
+    } on AppwriteException catch (e) {
+      throw Exception(
+        'AppwriteException: ${e.message ?? 'Unknown Appwrite error'}',
+      );
+    } catch (e) {
+      throw Exception(
+        'Unexpected error during function execution: $e',
+      );
+    }
+  }
+
+  /// Safely decodes JSON and guarantees a Map<String, dynamic>.
+  Map<String, dynamic> _decodeResponse(String body) {
+    if (body.isEmpty) {
+      throw Exception(
+        'Empty response body from Appwrite function.',
+      );
+    }
+
+    try {
+      final Object? decoded = jsonDecode(body);
+
+      if (decoded is! Map) {
+        throw Exception(
+          'Unexpected response format: expected JSON object.',
+        );
+      }
+
+      return Map<String, dynamic>.from(decoded);
+    } on FormatException {
+      throw Exception(
+        'Invalid JSON response from Appwrite function.',
+      );
+    } catch (e) {
+      throw Exception(
+        'Failed to parse response: $e',
+      );
+    }
+  }
 
   Future<Map<String, dynamic>> createRoom(
     String roomName,
     String roomDescription,
     String adminUid,
     List<String> roomTags,
-  ) async {
-    final data = {
-      "name": roomName,
-      "description": roomDescription,
-      "adminUid": adminUid,
-      "tags": roomTags,
-    };
-
-    try {
-      final response = await functions.createExecution(
-        functionId: createRoomServiceId,
-        body: json.encode(data),
-      );
-
-      if (response.responseStatusCode == 200) {
-        log(response.responseBody);
-
-        final Map<String, dynamic> responseData = jsonDecode(
-          response.responseBody,
-        );
-
-        return responseData;
-      } else {
-        throw Exception(
-          '${response.responseStatusCode}: ${response.responseBody}',
-        );
-      }
-    } on AppwriteException catch (error) {
-      throw Exception('ERROR $error');
-    }
+  ) {
+    return _executeFunction(
+      functionId: createRoomServiceId,
+      payload: {
+        'name': roomName,
+        'description': roomDescription,
+        'adminUid': adminUid,
+        'tags': roomTags,
+      },
+    );
   }
 
-  Future<Map<String, dynamic>> joinRoom(String roomName, String uid) async {
-    final data = {"roomName": roomName, "uid": uid};
-
-    try {
-      final response = await functions.createExecution(
-        functionId: joinRoomServiceId,
-        body: json.encode(data),
-      );
-
-      if (response.responseStatusCode == 200) {
-        log(response.responseBody);
-
-        final Map<String, dynamic> responseData = jsonDecode(
-          response.responseBody,
-        );
-
-        return responseData;
-      } else {
-        throw Exception(
-          '${response.responseStatusCode}: ${response.responseBody}',
-        );
-      }
-    } catch (error) {
-      throw Exception('ERROR $error');
-    }
+  Future<Map<String, dynamic>> joinRoom(
+    String roomName,
+    String uid,
+  ) {
+    return _executeFunction(
+      functionId: joinRoomServiceId,
+      payload: {
+        'roomName': roomName,
+        'uid': uid,
+      },
+    );
   }
 
   Future<Map<String, dynamic>> deleteRoom(
     String appwriteRoomDocId,
     String token,
-  ) async {
-    final data = {"appwriteRoomDocId": appwriteRoomDocId, "token": token};
-
-    try {
-      final response = await functions.createExecution(
-        functionId: deleteRoomServiceId,
-        body: json.encode(data),
-      );
-
-      if (response.responseStatusCode == 200) {
-        log(response.responseBody);
-
-        final Map<String, dynamic> responseData = jsonDecode(
-          response.responseBody,
-        );
-
-        return responseData;
-      } else {
-        throw Exception(
-          '${response.responseStatusCode}: ${response.responseBody}',
-        );
-      }
-    } catch (error) {
-      throw Exception('ERROR $error');
-    }
+  ) {
+    return _executeFunction(
+      functionId: deleteRoomServiceId,
+      payload: {
+        'appwriteRoomDocId': appwriteRoomDocId,
+        'token': token,
+      },
+    );
   }
 
   Future<Map<String, dynamic>> createLiveChapterRoom(
     String appwriteRoomId,
     String adminUid,
-  ) async {
-    final data = {"adminUid": adminUid, "appwriteRoomId": appwriteRoomId};
-
-    try {
-      final response = await functions.createExecution(
-        functionId: createLiveChapterRoomFunctionId,
-        body: json.encode(data),
-      );
-
-      if (response.responseStatusCode == 200) {
-        log(response.responseBody);
-
-        final Map<String, dynamic> responseData = jsonDecode(
-          response.responseBody,
-        );
-
-        return responseData;
-      } else {
-        throw Exception(
-          '${response.responseStatusCode}: ${response.responseBody}',
-        );
-      }
-    } on AppwriteException catch (error) {
-      throw Exception('ERROR $error');
-    }
+  ) {
+    return _executeFunction(
+      functionId: createLiveChapterRoomFunctionId,
+      payload: {
+        'adminUid': adminUid,
+        'appwriteRoomId': appwriteRoomId,
+      },
+    );
   }
 
   Future<Map<String, dynamic>> deleteLiveChapterRoom(
     String appwriteRoomDocId,
     String token,
-  ) async {
-    final data = {"appwriteRoomDocId": appwriteRoomDocId, "token": token};
-
-    try {
-      final response = await functions.createExecution(
-        functionId: deleteLiveChapterRoomFunctionId,
-        body: json.encode(data),
-      );
-
-      if (response.responseStatusCode == 200) {
-        log(response.responseBody);
-
-        final Map<String, dynamic> responseData = jsonDecode(
-          response.responseBody,
-        );
-
-        return responseData;
-      } else {
-        throw Exception(
-          '${response.responseStatusCode}: ${response.responseBody}',
-        );
-      }
-    } catch (error) {
-      throw Exception('ERROR $error');
-    }
+  ) {
+    return _executeFunction(
+      functionId: deleteLiveChapterRoomFunctionId,
+      payload: {
+        'appwriteRoomDocId': appwriteRoomDocId,
+        'token': token,
+      },
+    );
   }
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -9,8 +9,8 @@ class ApiService {
   static const Duration _functionTimeoutDuration =
       Duration(seconds: 30);
 
-  final Functions _functions =
-      Functions(AppwriteService.getClient());
+  Functions get _functions =>
+    Functions(AppwriteService.getClient());
 
   Future<Map<String, dynamic>> _executeFunction({
     required String functionId,


### PR DESCRIPTION
Description

This PR refactors ApiService to improve robustness and reduce duplicated logic across multiple methods.

Currently, each method (createRoom, joinRoom, deleteRoom, etc.) independently executes an Appwrite function, checks the response status, and parses the JSON response. This results in repeated code and assumes that responses are always valid JSON objects.

This refactor:

Centralizes function execution into a single private _executeFunction method
Adds defensive JSON parsing to ensure the response is a valid Map<String, dynamic>
Introduces a 30-second timeout to prevent indefinite hanging
Standardizes error handling across all methods

There are no changes to public method signatures, payload structure, or return types. This is strictly an internal improvement.

Fixes #766 

Type of change
 Refactor (does not change functionality, e.g. code style improvements, linting)

How Has This Been Tested?

Ran the application locally and verified:
Room creation works as expected
Joining a room works correctly
Deleting rooms behaves normally
Confirmed that existing flows using ApiService continue to function without modification

Verified no new analyzer warnings were introduced

Checklist:

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 My changes generate no new warnings
 I have checked my code and corrected any misspellings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized API execution flow with consistent timeouts and standardized request/response handling for room-related operations (create, join, delete, live chapter rooms).
* **Bug Fixes**
  * Improved JSON response validation and clearer, descriptive error messages for timeouts and failures to reduce silent or inconsistent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->