### PR TITLE
fix: guard empty documents list before accessing .first (fixes #778)

### DIFF
--- a/lib/controllers/upcomming_rooms_controller.dart
+++ b/lib/controllers/upcomming_rooms_controller.dart
@@ -105,19 +105,23 @@ class UpcomingRoomsController extends GetxController {
 
   Future<void> removeUserFromSubscriberList(String upcomingRoomId) async {
     try {
-      var subscribeDocument = await databases
-          .listDocuments(
-            databaseId: upcomingRoomsDatabaseId,
-            collectionId: subscribedUserCollectionId,
-            queries: [
-              Query.and([
-                Query.equal('userID', authStateController.uid),
-                Query.equal('upcomingRoomId', upcomingRoomId),
-              ]),
-            ],
-          )
-          .then((value) => value.documents.first);
+      var response = await databases.listDocuments(
+        databaseId: upcomingRoomsDatabaseId,
+        collectionId: subscribedUserCollectionId,
+        queries: [
+          Query.and([
+            Query.equal('userId', authStateController.uid),
+            Query.equal('upcomingRoomId', upcomingRoomId),
+          ]),
+        ],
+      );
 
+      if (response.documents.isEmpty) {
+        // Nothing to remove, user is not subscribed
+        return;
+      }
+
+var subscribeDocument = response.documents.first;
       await databases.deleteDocument(
         databaseId: upcomingRoomsDatabaseId,
         collectionId: subscribedUserCollectionId,

--- a/lib/controllers/upcomming_rooms_controller.dart
+++ b/lib/controllers/upcomming_rooms_controller.dart
@@ -110,7 +110,7 @@ class UpcomingRoomsController extends GetxController {
         collectionId: subscribedUserCollectionId,
         queries: [
           Query.and([
-            Query.equal('userId', authStateController.uid),
+            Query.equal('userID', authStateController.uid),
             Query.equal('upcomingRoomId', upcomingRoomId),
           ]),
         ],


### PR DESCRIPTION
## Description

Fixes #778

Adds a defensive guard in `removeUserFromSubscriberList` to prevent a 
`StateError` when accessing `response.documents.first` if the list is empty.

Previously, calling `.first` on an empty list could cause a runtime crash.  
The method now safely returns early when no matching subscription document exists.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings