### PR TITLE
fix: guard unsafe .first access in realtime listeners and query results (#782)

### DIFF
--- a/lib/controllers/explore_story_controller.dart
+++ b/lib/controllers/explore_story_controller.dart
@@ -626,14 +626,18 @@ class ExploreStoryController extends GetxController {
       log('Failed to fetch Like Document: ${e.message}');
     }
 
-    try {
-      await databases.deleteDocument(
-        databaseId: storyDatabaseId,
-        collectionId: likeCollectionId,
-        documentId: userLikeDocuments.first.$id,
-      );
-    } on AppwriteException catch (e) {
-      log('Failed to Unlike i.e delete Like Document: ${e.message}');
+    if (userLikeDocuments.isNotEmpty) {
+      try {
+        await databases.deleteDocument(
+          databaseId: storyDatabaseId,
+          collectionId: likeCollectionId,
+          documentId: userLikeDocuments.first.$id,
+        );
+      } on AppwriteException catch (e) {
+        log('Failed to Unlike i.e delete Like Document: ${e.message}');
+      }
+    } else {
+      log('No like document found to delete');
     }
 
     try {

--- a/lib/controllers/friend_calling_controller.dart
+++ b/lib/controllers/friend_calling_controller.dart
@@ -197,6 +197,7 @@ class FriendCallingController extends GetxController {
         'databases.$masterDatabaseId.collections.$friendCallsCollectionId.documents.${friendCallModel.value!.docId}';
     callSubscription = realtime.subscribe([channel]);
     callSubscription?.stream.listen((data) async {
+      if (data.events.isEmpty) return;
       if (data.payload.isNotEmpty) {
         if (data.events.first.endsWith('.update')) {
           if (data.payload['callStatus'] == FriendCallStatus.connected.name) {

--- a/lib/controllers/live_chapter_controller.dart
+++ b/lib/controllers/live_chapter_controller.dart
@@ -44,6 +44,7 @@ class LiveChapterController extends GetxController {
         "databases.$userDatabaseID.collections.$liveChapterAttendeesCollectionId.documents.${liveChapterModel.value!.id}";
     liveChapterAttendeesSubscription = realtime.subscribe([channel]);
     liveChapterAttendeesSubscription?.stream.listen((data) async {
+      if (data.events.isEmpty) return;
       if (data.payload.isNotEmpty) {
         if (data.events.first.endsWith('.update')) {
           log("update detected");

--- a/lib/controllers/pair_chat_controller.dart
+++ b/lib/controllers/pair_chat_controller.dart
@@ -112,6 +112,7 @@ class PairChatController extends GetxController {
         'databases.$masterDatabaseId.collections.$activePairsCollectionId.documents';
     subscription = realtime.subscribe([channel]);
     subscription?.stream.listen((data) async {
+      if (data.events.isEmpty) return;
       if (data.payload.isNotEmpty) {
         String uid1 = data.payload["uid1"];
         String uid2 = data.payload["uid2"];
@@ -182,6 +183,7 @@ class PairChatController extends GetxController {
         'databases.$masterDatabaseId.collections.$pairRequestCollectionId.documents';
     userAddedSubscription = realtime.subscribe([channel]);
     userAddedSubscription?.stream.listen((data) async {
+      if (data.events.isEmpty) return;
       final event = data.events.first;
       if (data.payload.isNotEmpty) {
         if (event.endsWith('.create')) {

--- a/lib/controllers/room_chat_controller.dart
+++ b/lib/controllers/room_chat_controller.dart
@@ -200,6 +200,7 @@ class RoomChatController extends GetxController {
           'databases.$masterDatabaseId.collections.$chatMessagesCollectionId.documents';
       subscription = realtime.subscribe([channel]);
       subscription?.stream.listen((data) async {
+        if (data.events.isEmpty) return;
         if (data.payload.isNotEmpty) {
           String roomId = data.payload['roomId'];
           if (roomId == (appwriteRoom?.id ?? appwriteUpcommingRoom!.id)) {

--- a/lib/controllers/single_room_controller.dart
+++ b/lib/controllers/single_room_controller.dart
@@ -136,6 +136,7 @@ class SingleRoomController extends GetxController {
         'databases.$masterDatabaseId.collections.$participantsCollectionId.documents';
     subscription = realtime.subscribe([channel]);
     subscription?.stream.listen((data) async {
+      if (data.events.isEmpty) return;
       if (data.payload.isNotEmpty) {
         String roomId = data.payload["roomId"];
         if (roomId == appwriteRoom.id) {
@@ -244,6 +245,10 @@ class SingleRoomController extends GetxController {
         Query.equal('uid', participant.uid),
       ],
     );
+    if (participantDocsRef.documents.isEmpty) {
+      return null; // or handle appropriately
+    }
+
     return participantDocsRef.documents.first.$id;
   }
 

--- a/lib/controllers/single_room_controller.dart
+++ b/lib/controllers/single_room_controller.dart
@@ -236,7 +236,7 @@ class SingleRoomController extends GetxController {
     }
   }
 
-  Future<String> getParticipantDocId(Participant participant) async {
+  Future<String?> getParticipantDocId(Participant participant) async {
     var participantDocsRef = await databases.listDocuments(
       databaseId: masterDatabaseId,
       collectionId: participantsCollectionId,
@@ -293,7 +293,8 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> makeModerator(Participant participant) async {
-    String participantDocId = await getParticipantDocId(participant);
+    final participantDocId = await getParticipantDocId(participant);
+    if (participantDocId == null) return;
     await updateParticipantDoc(participantDocId, {
       "isSpeaker": true,
       "hasRequestedToBeSpeaker": false,
@@ -302,7 +303,8 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> removeModerator(Participant participant) async {
-    String participantDocId = await getParticipantDocId(participant);
+    final participantDocId = await getParticipantDocId(participant);
+    if (participantDocId == null) return;
     await updateParticipantDoc(participantDocId, {
       "isSpeaker": false,
       "hasRequestedToBeSpeaker": false,
@@ -336,7 +338,8 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> makeSpeaker(Participant participant) async {
-    String participantDocId = await getParticipantDocId(participant);
+    final participantDocId = await getParticipantDocId(participant);
+    if (participantDocId == null) return;
     await updateParticipantDoc(participantDocId, {
       "isSpeaker": true,
       "hasRequestedToBeSpeaker": false,
@@ -344,7 +347,8 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> makeListener(Participant participant) async {
-    String participantDocId = await getParticipantDocId(participant);
+    final participantDocId = await getParticipantDocId(participant);
+    if (participantDocId == null) return;
     await updateParticipantDoc(participantDocId, {
       "isSpeaker": false,
       "hasRequestedToBeSpeaker": false,
@@ -352,7 +356,8 @@ class SingleRoomController extends GetxController {
   }
 
   Future<void> kickOutParticipant(Participant participant) async {
-    String participantDocId = await getParticipantDocId(participant);
+    final participantDocId = await getParticipantDocId(participant);
+    if (participantDocId == null) return;
     await databases.deleteDocument(
       databaseId: masterDatabaseId,
       collectionId: participantsCollectionId,

--- a/lib/controllers/upcomming_rooms_controller.dart
+++ b/lib/controllers/upcomming_rooms_controller.dart
@@ -116,7 +116,12 @@ class UpcomingRoomsController extends GetxController {
               ]),
             ],
           )
-          .then((value) => value.documents.first);
+          .then((value) {
+            if (value.documents.isEmpty) {
+              throw Exception('No documents found');
+            }
+            return value.documents.first;
+          });
 
       await databases.deleteDocument(
         databaseId: upcomingRoomsDatabaseId,

--- a/lib/controllers/upcomming_rooms_controller.dart
+++ b/lib/controllers/upcomming_rooms_controller.dart
@@ -105,23 +105,23 @@ class UpcomingRoomsController extends GetxController {
 
   Future<void> removeUserFromSubscriberList(String upcomingRoomId) async {
     try {
-      var subscribeDocument = await databases
-          .listDocuments(
-            databaseId: upcomingRoomsDatabaseId,
-            collectionId: subscribedUserCollectionId,
-            queries: [
-              Query.and([
-                Query.equal('userID', authStateController.uid),
-                Query.equal('upcomingRoomId', upcomingRoomId),
-              ]),
-            ],
-          )
-          .then((value) {
-            if (value.documents.isEmpty) {
-              throw Exception('No documents found');
-            }
-            return value.documents.first;
-          });
+      final result = await databases.listDocuments(
+        databaseId: upcomingRoomsDatabaseId,
+        collectionId: subscribedUserCollectionId,
+        queries: [
+          Query.and([
+            Query.equal('userID', authStateController.uid),
+            Query.equal('upcomingRoomId', upcomingRoomId),
+          ]),
+        ],
+      );
+
+      if (result.documents.isEmpty) {
+        log('No subscriber document found for user/room; skipping delete');
+        return;
+      }
+
+final subscribeDocument = result.documents.first;
 
       await databases.deleteDocument(
         databaseId: upcomingRoomsDatabaseId,


### PR DESCRIPTION
Description

This PR prevents runtime crashes caused by unsafe .first access on potentially empty lists in realtime listeners and Appwrite query results.

Several controllers were directly accessing:
data.events.first
documents.first

Without checking if the list was empty. If the realtime event list or query result returned an empty list, this would throw:

```dart
StateError: No element
```

Changes made

Added if (data.events.isEmpty) return; before accessing data.events.first
Added isEmpty checks before accessing documents.first
Added safe guards for query result handling to prevent crashes when no documents are returned
These changes ensure the app fails safely instead of crashing in edge cases such as empty realtime events or concurrent deletions.

Fixes #782

Type of change
 Bug fix (non-breaking change which fixes an issue)

Checklist

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 My changes generate no new warnings
 I have checked my code and corrected any misspellings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors and crashes across messaging, calling, and room features by skipping processing when realtime payloads are empty.
  * Made participant lookup and moderator/speaker actions safer to avoid failures when no matching participant is found.
  * Fixed story unlike and subscriber removal flows to avoid exceptions when expected documents are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->