### PR TITLE
fix: guard rating calculation when ratingCount is zero (fixes #780)

### DIFF
--- a/lib/controllers/explore_story_controller.dart
+++ b/lib/controllers/explore_story_controller.dart
@@ -198,8 +198,11 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc.$id;
       userData['uid'] = doc.$id;
       userData['userName'] = userData['username'];
+      final ratingTotal = userData['ratingTotal'] ?? 0;
+      final ratingCount = userData['ratingCount'] ?? 0;
+
       userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+          ratingCount > 0 ? ratingTotal / ratingCount : 0.0;
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);
@@ -217,8 +220,11 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc['\$id'];
       userData['uid'] = doc['\$id'];
       userData['userName'] = userData['username'];
+      final ratingTotal = userData['ratingTotal'] ?? 0;
+      final ratingCount = userData['ratingCount'] ?? 0;
+
       userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+          ratingCount > 0 ? ratingTotal / ratingCount : 0.0;
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);


### PR DESCRIPTION
## Description

Fixes #780

Guards the user rating calculation in `explore_story_controller.dart` to prevent invalid numeric results when `ratingCount` is zero or null.

Previously, the rating was calculated as:

```dart
userData['ratingTotal'] / userData['ratingCount'];
```

If ratingCount was 0 or null, this could produce NaN or Infinity, leading to incorrect values being displayed in the UI.

The calculation now safely returns 0.0 when ratingCount is not greater than zero.

Type of change
 Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?

Manually tested with ratingCount = 0
Manually tested with ratingCount = null
Verified valid division when ratingCount > 0
Confirmed no NaN or Infinity values are produced

Checklist:

 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have made corresponding changes to the documentation
 I have added tests that prove my fix is effective
 My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash when calculating user ratings in the explore section by adding proper validation to prevent division by zero errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->