### PR TITLE
Category responsive + fix scrollable 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,31 +77,38 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     UiSizes.init(context);
     final themeController = Get.put(ThemeController());
+    return ScreenUtilInit(
+        designSize: const Size(360, 690),
+        minTextAdapt: true,
+        splitScreenMode: true,
+        // Use builder only if you need to use library outside ScreenUtilInit context
+        builder: (_ , child) {
+          return Obx(
+                () => GetMaterialApp(
+              localizationsDelegates: [
+                AppLocalizations.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              locale: Locale(languageLocale),
+              supportedLocales: AppLocalizations.supportedLocales,
+              debugShowCheckedModeBanner: false,
+              title: 'Resonate',
+              theme: ThemeModes.setLightTheme(
+                ThemeList.getThemeModel(themeController.currentTheme.value),
+              ),
+              darkTheme: ThemeModes.setDarkTheme(
+                ThemeList.getThemeModel(themeController.currentTheme.value),
+              ),
+              themeMode: ThemeList.getThemeModel(
+                themeController.currentTheme.value,
+              ).themeMode,
+              initialRoute: AppRoutes.splash,
+              getPages: AppPages.pages,
+            ),
+          );
+        });
 
-    return Obx(
-      () => GetMaterialApp(
-        localizationsDelegates: [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        locale: Locale(languageLocale),
-        supportedLocales: AppLocalizations.supportedLocales,
-        debugShowCheckedModeBanner: false,
-        title: 'Resonate',
-        theme: ThemeModes.setLightTheme(
-          ThemeList.getThemeModel(themeController.currentTheme.value),
-        ),
-        darkTheme: ThemeModes.setDarkTheme(
-          ThemeList.getThemeModel(themeController.currentTheme.value),
-        ),
-        themeMode: ThemeList.getThemeModel(
-          themeController.currentTheme.value,
-        ).themeMode,
-        initialRoute: AppRoutes.splash,
-        getPages: AppPages.pages,
-      ),
-    );
   }
 }

--- a/lib/views/screens/category_screen.dart
+++ b/lib/views/screens/category_screen.dart
@@ -19,66 +19,68 @@ class CategoryScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        automaticallyImplyLeading: false,
+        automaticallyImplyLeading: true,//back button for user experience
+        centerTitle: true,
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
         title: Text(capitalizeFirstLetter(categoryName)),
       ),
       body: Obx(
-        () => exploreStoryController.isLoadingCategoryPage.value
+            () => exploreStoryController.isLoadingCategoryPage.value
             ? Center(
-                child: SizedBox(
-                  height: 200,
-                  width: 200,
-                  child: LoadingIndicator(
-                    indicatorType: Indicator.ballRotate,
-                    colors: [Theme.of(context).colorScheme.primary],
-                  ),
-                ),
-              )
+          child: SizedBox(
+            height: 200,
+            width: 200,
+            child: LoadingIndicator(
+              indicatorType: Indicator.ballRotate,
+              colors: [Theme.of(context).colorScheme.primary],
+            ),
+          ),
+        )
             : exploreStoryController.openedCategotyStories.isNotEmpty
             ? Padding(
-                padding: const EdgeInsets.only(top: 20.0),
-                child: ListView.builder(
-                  physics: const NeverScrollableScrollPhysics(),
-                  scrollDirection: Axis.vertical,
-                  padding: EdgeInsets.zero,
-                  shrinkWrap: true,
-                  primary: true,
-                  itemCount:
-                      exploreStoryController.openedCategotyStories.length,
-                  itemBuilder: (context, index) {
-                    final int storyIndex = index;
-                    return StoryListTile(
-                      story: exploreStoryController
-                          .openedCategotyStories[storyIndex],
-                    );
-                  },
-                ),
-              )
+          padding: const EdgeInsets.only(top: 20.0),
+          child: ListView.builder(
+            physics: const NeverScrollableScrollPhysics(),
+            scrollDirection: Axis.vertical,
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            primary: true,
+            itemCount:
+            exploreStoryController.openedCategotyStories.length,
+            itemBuilder: (context, index) {
+              final int storyIndex = index;
+              return StoryListTile(
+                story: exploreStoryController
+                    .openedCategotyStories[storyIndex],
+              );
+            },
+          ),
+        )
             : Padding(
-                padding: const EdgeInsets.only(bottom: 150.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Image.asset(
-                      height: 200,
-                      width: 200,
-                      AppImages.emptyBoxImage,
-                    ),
-                    const SizedBox(height: 20),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 30.0),
-                      child: Text(
-                        AppLocalizations.of(context)!.noStoriesInCategory(
-                          capitalizeFirstLetter(categoryName),
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ],
+          padding: const EdgeInsets.only(bottom: 150.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,// take the least size needed
+            children: [
+              Image.asset(
+                height: 200,
+                width: 200,
+                AppImages.emptyBoxImage,
+              ),
+              const SizedBox(height: 20),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 30.0),
+                child: Text(
+                  AppLocalizations.of(context)!.noStoriesInCategory(
+                    capitalizeFirstLetter(categoryName),
+                  ),
+                  textAlign: TextAlign.center,
                 ),
               ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/views/screens/category_screen.dart
+++ b/lib/views/screens/category_screen.dart
@@ -20,65 +20,63 @@ class CategoryScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        automaticallyImplyLeading: true,//back button for user experience
+        automaticallyImplyLeading: true, //back button for user experience
         centerTitle: true,
         backgroundColor: Theme.of(context).colorScheme.surface,
         elevation: 0,
         title: Text(capitalizeFirstLetter(categoryName)),
       ),
       body: Obx(
-            () => exploreStoryController.isLoadingCategoryPage.value
+        () => exploreStoryController.isLoadingCategoryPage.value
             ? Center(
-          child: SizedBox(
-            height: 200.h,
-            width: 200.w,
-            child: LoadingIndicator(
-              indicatorType: Indicator.ballRotate,
-              colors: [Theme.of(context).colorScheme.primary],
-            ),
-          ),
-        )
+                child: SizedBox(
+                  height: 200.h,
+                  width: 200.w,
+                  child: LoadingIndicator(
+                    indicatorType: Indicator.ballRotate,
+                    colors: [Theme.of(context).colorScheme.primary],
+                  ),
+                ),
+              )
             : exploreStoryController.openedCategotyStories.isNotEmpty
             ? Padding(
-          padding:  EdgeInsets.only(top: 20.0.h),
-          child: ListView.builder(
-            scrollDirection: Axis.vertical,
-            padding: EdgeInsets.zero,
-            itemCount:
-            exploreStoryController.openedCategotyStories.length,
-            itemBuilder: (context, index) {
-              final int storyIndex = index;
-              return StoryListTile(
-                story: exploreStoryController
-                    .openedCategotyStories[storyIndex],
-              );
-            },
-          ),
-        )
-            : Padding(
-          padding:  EdgeInsets.only(bottom: 150.0.h),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            mainAxisSize: MainAxisSize.min,// take the least size needed
-            children: [
-              Image.asset(
-                height: 200.h,
-                width: 200.w,
-                AppImages.emptyBoxImage,
-              ),
-               SizedBox(height: 20.h),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: 30.0.w),
-                child: Text(
-                  AppLocalizations.of(context)!.noStoriesInCategory(
-                    capitalizeFirstLetter(categoryName),
+                padding: EdgeInsets.only(top: 20.0.h),
+                child: ListView.builder(
+                  padding: EdgeInsets.zero,
+                  itemCount:
+                      exploreStoryController.openedCategotyStories.length,
+                  itemBuilder: (context, index) {
+                    final int storyIndex = index;
+                    return StoryListTile(
+                      story: exploreStoryController
+                          .openedCategotyStories[storyIndex],
+                    );
+                  },
+                ),
+              )
+            : Center(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 30.0.w),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Image.asset(
+                        height: 200.h,
+                        width: 200.w,
+                        AppImages.emptyBoxImage,
+                      ),
+                      SizedBox(height: 20.h),
+                      Text(
+                        AppLocalizations.of(context)!.noStoriesInCategory(
+                          capitalizeFirstLetter(categoryName),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
                   ),
-                  textAlign: TextAlign.center,
                 ),
               ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/views/screens/category_screen.dart
+++ b/lib/views/screens/category_screen.dart
@@ -6,6 +6,7 @@ import 'package:resonate/controllers/explore_story_controller.dart';
 import 'package:resonate/utils/app_images.dart';
 import 'package:resonate/views/widgets/category_card.dart';
 import 'package:resonate/views/widgets/story_list_tile.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class CategoryScreen extends StatelessWidget {
   CategoryScreen({super.key, required this.categoryName});
@@ -29,8 +30,8 @@ class CategoryScreen extends StatelessWidget {
             () => exploreStoryController.isLoadingCategoryPage.value
             ? Center(
           child: SizedBox(
-            height: 200,
-            width: 200,
+            height: 200.h,
+            width: 200.w,
             child: LoadingIndicator(
               indicatorType: Indicator.ballRotate,
               colors: [Theme.of(context).colorScheme.primary],
@@ -39,13 +40,10 @@ class CategoryScreen extends StatelessWidget {
         )
             : exploreStoryController.openedCategotyStories.isNotEmpty
             ? Padding(
-          padding: const EdgeInsets.only(top: 20.0),
+          padding:  EdgeInsets.only(top: 20.0.h),
           child: ListView.builder(
-            physics: const NeverScrollableScrollPhysics(),
             scrollDirection: Axis.vertical,
             padding: EdgeInsets.zero,
-            shrinkWrap: true,
-            primary: true,
             itemCount:
             exploreStoryController.openedCategotyStories.length,
             itemBuilder: (context, index) {
@@ -58,19 +56,19 @@ class CategoryScreen extends StatelessWidget {
           ),
         )
             : Padding(
-          padding: const EdgeInsets.only(bottom: 150.0),
+          padding:  EdgeInsets.only(bottom: 150.0.h),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,// take the least size needed
             children: [
               Image.asset(
-                height: 200,
-                width: 200,
+                height: 200.h,
+                width: 200.w,
                 AppImages.emptyBoxImage,
               ),
-              const SizedBox(height: 20),
+               SizedBox(height: 20.h),
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 30.0),
+                padding: EdgeInsets.symmetric(horizontal: 30.0.w),
                 child: Text(
                   AppLocalizations.of(context)!.noStoriesInCategory(
                     capitalizeFirstLetter(categoryName),

--- a/lib/views/screens/category_screen.dart
+++ b/lib/views/screens/category_screen.dart
@@ -40,7 +40,7 @@ class CategoryScreen extends StatelessWidget {
               )
             : exploreStoryController.openedCategotyStories.isNotEmpty
             ? Padding(
-                padding: EdgeInsets.only(top: 20.0.h),
+                padding: EdgeInsets.only(top: 20.h),
                 child: ListView.builder(
                   padding: EdgeInsets.zero,
                   itemCount:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run flutter pub outdated.
 dependencies:
+  flutter_screenutil: ^5.9.3
   animated_bottom_navigation_bar: ^1.4.0
   animated_splash_screen: ^1.3.0
   app_links: ^6.4.1


### PR DESCRIPTION
## Description

This pull request fixes UI and usability issues in the CategoryScreen.

Fixed a critical issue where the ListView was not scrollable due to incorrect configuration (NeverScrollableScrollPhysics, shrinkWrap, and primary used together).
Improved layout responsiveness by removing hard-coded bottom padding (150.0) and replacing it with a centered layout for better adaptability across different screen sizes.

These changes improve user experience, ensure proper scrolling behavior, and make the UI responsive on all devices.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [o] Bug fix (non-breaking CHANGE which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [o] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?
Ran the application on emulator and verified:
The list of stories scrolls correctly.
No scrolling issues occur when the list is long.
Tested empty state:
Verified that the empty-state UI is properly centered on different screen sizes.
Tested on multiple screen sizes using responsive tools (flutter_screenutil).

Steps to reproduce:

Open the app
Navigate to CategoryScreen
Verify:
Stories list scrolls normally
Empty state appears centered when no data is available

## Checklist:

- [o] My code follows the style guidelines of this project
- [o] I have performed a self-review of my own code
- [o] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [o] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [o] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [o] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [o] closes #796
- [ ] Tag the PR with the appropriate labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now initializes a global responsive scaling system for consistent layout across devices.

* **Improvements**
  * Enabled default back navigation and centered category screen titles.
  * Made list rendering more natural for story feeds.
  * Improved empty-state and loading visuals with responsive sizing and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->