### PR TITLE
fix overflow bug cause 2 expanded in the same column

### DIFF
--- a/lib/views/screens/add_chapter_screen.dart
+++ b/lib/views/screens/add_chapter_screen.dart
@@ -90,7 +90,7 @@ class AddNewChapterScreenState extends State<AddNewChapterScreen> {
               style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 10),
-            Expanded(
+               Flexible(
               child: ListView.builder(
                 itemCount: newChapters.length,
                 itemBuilder: (context, index) {


### PR DESCRIPTION
## Description

There are 2 Expanded widgets in the same column in the add_chapter_screen, so there is an overflow
Fixes # (issue)
Replace one Expanded with a Flexible widget
## Type of change

Please delete options that are not relevant.

- [o] Bug fix (non-breaking CHANGE which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

I used multiple emulator to test this bug

Please include screenshots below if applicable.

## Checklist:

- [o] My code follows the style guidelines of this project
- [p] I have performed a self-review of my own code
- [o] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [o] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [o] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [o] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [o] closes #803
- [ ] Tag the PR with the appropriate labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted layout constraints for the chapters list to improve space allocation within the screen layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->