### PR TITLE
fix: guard division by zero in rating calculations (#814)

### DIFF
--- a/lib/controllers/auth_state_controller.dart
+++ b/lib/controllers/auth_state_controller.dart
@@ -49,6 +49,9 @@ class AuthStateController extends GetxController {
   late bool? isEmailVerified;
   late double ratingTotal;
   late int ratingCount;
+
+  double get averageRating =>
+      ratingCount > 0 ? ratingTotal / ratingCount : 5.0;
   late User appwriteUser;
   late List<FollowerUserModel> followerDocuments;
   late int reportsCount;
@@ -211,7 +214,7 @@ class AuthStateController extends GetxController {
         profileImageUrl = userDataDoc.data["profileImageUrl"];
         profileImageID = userDataDoc.data["profileImageID"];
         userName = userDataDoc.data["username"] ?? "unavailable";
-        ratingTotal = userDataDoc.data["ratingTotal"].toDouble() ?? 5;
+        ratingTotal = (userDataDoc.data["ratingTotal"] ?? 5).toDouble();
         ratingCount = userDataDoc.data["ratingCount"] ?? 1;
         followerDocuments =
             (userDataDoc.data["followers"] as List<dynamic>?)?.map((e) {

--- a/lib/controllers/explore_story_controller.dart
+++ b/lib/controllers/explore_story_controller.dart
@@ -198,8 +198,10 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc.$id;
       userData['uid'] = doc.$id;
       userData['userName'] = userData['username'];
+      final ratingTotal = userData['ratingTotal'] ?? 5;
+      final ratingCount = userData['ratingCount'] ?? 1;
       userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+          ratingCount > 0 ? ratingTotal / ratingCount : 5.0;
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);
@@ -217,8 +219,10 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc['\$id'];
       userData['uid'] = doc['\$id'];
       userData['userName'] = userData['username'];
+      final ratingTotal = userData['ratingTotal'] ?? 5;
+      final ratingCount = userData['ratingCount'] ?? 1;
       userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+          ratingCount > 0 ? ratingTotal / ratingCount : 5.0;
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);

--- a/lib/controllers/friends_controller.dart
+++ b/lib/controllers/friends_controller.dart
@@ -65,8 +65,7 @@ class FriendsController extends GetxController {
       docId: docId,
       senderFCMToken: userFCMToken,
       users: [authStateController.uid!, recieverId],
-      senderRating:
-          authStateController.ratingTotal / authStateController.ratingCount,
+      senderRating: authStateController.averageRating,
       recieverRating: recieverRating,
     );
     await databases.createDocument(

--- a/lib/controllers/pair_chat_controller.dart
+++ b/lib/controllers/pair_chat_controller.dart
@@ -80,7 +80,7 @@ class PairChatController extends GetxController {
       "profileImageUrl": authController.profileImageUrl,
       "userName": authController.userName,
       "name": authController.displayName,
-      "userRating": authController.ratingTotal / authController.ratingCount,
+      "userRating": authController.averageRating,
     };
 
     // Add request to pair-request collection

--- a/lib/controllers/user_profile_controller.dart
+++ b/lib/controllers/user_profile_controller.dart
@@ -149,8 +149,7 @@ class UserProfileController extends GetxController {
       name: authStateController.displayName!,
       fcmToken: fcmToken!,
       followingUserId: creatorId,
-      followerRating:
-          authStateController.ratingTotal / authStateController.ratingCount,
+      followerRating: authStateController.averageRating,
     );
 
     await databases.createDocument(


### PR DESCRIPTION
## Description

Fixes division by zero crash when `ratingCount` is zero for new users or uninitialized state.

## Changes

- **auth_state_controller.dart**: Added `averageRating` getter with zero-guard + null-safe API data parsing
- **pair_chat_controller.dart**: Use `averageRating` getter instead of raw division
- **friends_controller.dart**: Use `averageRating` getter instead of raw division
- **user_profile_controller.dart**: Use `averageRating` getter instead of raw division
- **explore_story_controller.dart**: Added zero-guard + null defaults at both division sites

Fixes #814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rating calculations so profiles, search results, chat, and friend/follow actions use a safe average instead of failing on missing or zero values.
  * Fixed default rating handling to ensure users still see a sensible score when rating data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->