### PR TITLE
feat: integrate in-room chat cloud function with mute support

### DIFF
--- a/lib/controllers/room_chat_controller.dart
+++ b/lib/controllers/room_chat_controller.dart
@@ -27,6 +27,7 @@ class RoomChatController extends GetxController {
   final TablesDB tablesDB = AppwriteService.getTables();
   late final RealtimeSubscription? subscription;
   Rx<ReplyTo?> replyingTo = Rxn<ReplyTo>();
+  RxBool isMuted = false.obs;
   final NotificationDetails notificationDetails = NotificationDetails(
     android: AndroidNotificationDetails(
       'your channel id',
@@ -38,28 +39,67 @@ class RoomChatController extends GetxController {
     ),
   );
 
+  bool get isAdmin => appwriteRoom?.isUserAdmin ?? false;
+  String get _roomId => appwriteRoom?.id ?? appwriteUpcommingRoom!.id;
+
   @override
   void onInit() async {
     super.onInit();
     subscribeToMessages();
+    await checkMuteStatus();
     log(appwriteRoom.toString());
     log(appwriteUpcommingRoom.toString());
   }
 
-  // delete method
+  Future<void> checkMuteStatus() async {
+    try {
+      if (chatFunctionId.isNotEmpty) {
+        var response = await functions.createExecution(
+          functionId: chatFunctionId,
+          body: json.encode({
+            'action': 'checkMute',
+            'roomId': _roomId,
+            'uid': requireCurrentAuthUser.uid,
+          }),
+        );
+        if (response.responseStatusCode == 200) {
+          var result = jsonDecode(response.responseBody);
+          isMuted.value = result['isMuted'] ?? false;
+        }
+      }
+    } catch (e) {
+      log('Error checking mute status: $e');
+    }
+  }
+
   Future<void> deleteMessage(String messageId) async {
     try {
-      Message messageToDelete = messages.firstWhere(
-        (msg) => msg.messageId == messageId,
-      );
-      messageToDelete = messageToDelete.copyWith(content: '', isDeleted: true);
+      if (chatFunctionId.isNotEmpty) {
+        var response = await functions.createExecution(
+          functionId: chatFunctionId,
+          body: json.encode({
+            'action': 'delete',
+            'messageId': messageId,
+            'uid': requireCurrentAuthUser.uid,
+          }),
+        );
+        if (response.responseStatusCode != 200) {
+          throw Exception('Failed to delete message via cloud function');
+        }
+      } else {
+        Message messageToDelete = messages.firstWhere(
+          (msg) => msg.messageId == messageId,
+        );
+        messageToDelete =
+            messageToDelete.copyWith(content: '', isDeleted: true);
 
-      await tablesDB.updateRow(
-        databaseId: masterDatabaseId,
-        tableId: chatMessagesTableId,
-        rowId: messageId,
-        data: messageToDelete.toJsonForUpload(),
-      );
+        await tablesDB.updateRow(
+          databaseId: masterDatabaseId,
+          tableId: chatMessagesTableId,
+          rowId: messageId,
+          data: messageToDelete.toJsonForUpload(),
+        );
+      }
       log('Message deleted successfully');
     } catch (e) {
       log('Error deleting message: $e');
@@ -70,7 +110,7 @@ class RoomChatController extends GetxController {
   Future<void> loadMessages() async {
     messages.clear();
     var queries = [
-      Query.equal('roomId', appwriteRoom?.id ?? appwriteUpcommingRoom!.id),
+      Query.equal('roomId', _roomId),
       Query.orderAsc('index'),
       Query.limit(100),
     ];
@@ -90,10 +130,9 @@ class RoomChatController extends GetxController {
         replyTo = ReplyTo.fromJson(replyToDoc.data);
       } catch (e) {
         if (e is AppwriteException && e.code == 404) {
-          // If replyTo document not found, set it to null
           replyTo = null;
         } else {
-          rethrow; // Rethrow if it's a different error
+          rethrow;
         }
       }
       messages.add(
@@ -106,47 +145,78 @@ class RoomChatController extends GetxController {
 
   Future<void> sendMessage(String content) async {
     try {
-      final String messageId = ID.unique();
-
-      final int newIndex = messages.isNotEmpty ? messages.last.index + 1 : 0;
       final user = requireCurrentAuthUser;
-      final Message message = Message(
-        roomId: appwriteRoom?.id ?? appwriteUpcommingRoom!.id,
-        messageId: messageId,
-        creatorId: user.uid,
-        creatorUsername: user.userName ?? '',
-        creatorName: user.displayName,
-        hasValidTag: false,
-        index: newIndex,
-        creatorImgUrl: user.profileImageUrl ?? '',
-        isEdited: false,
-        content: content,
-        creationDateTime: DateTime.now(),
-        isDeleted: false,
-      );
 
-      await tablesDB.createRow(
-        databaseId: masterDatabaseId,
-        tableId: chatMessagesTableId,
-        rowId: messageId,
-        data: message.toJsonForUpload(),
-      );
+      if (chatFunctionId.isNotEmpty) {
+        final String messageId = ID.unique();
+        var response = await functions.createExecution(
+          functionId: chatFunctionId,
+          body: json.encode({
+            'action': 'send',
+            'messageId': messageId,
+            'roomId': _roomId,
+            'creatorId': user.uid,
+            'creatorUsername': user.userName ?? '',
+            'creatorName': user.displayName,
+            'creatorImgUrl': user.profileImageUrl ?? '',
+            'content': content,
+          }),
+        );
+        if (response.responseStatusCode != 200) {
+          throw Exception('Failed to send message');
+        }
+        if (replyingTo.value != null) {
+          await tablesDB.createRow(
+            databaseId: masterDatabaseId,
+            tableId: chatMessageReplyTableId,
+            rowId: messageId,
+            data: replyingTo.value!.toJson(),
+          );
+        }
+      } else {
+        final String messageId = ID.unique();
+        final int newIndex =
+            messages.isNotEmpty ? messages.last.index + 1 : 0;
+        final Message message = Message(
+          roomId: _roomId,
+          messageId: messageId,
+          creatorId: user.uid,
+          creatorUsername: user.userName ?? '',
+          creatorName: user.displayName,
+          hasValidTag: false,
+          index: newIndex,
+          creatorImgUrl: user.profileImageUrl ?? '',
+          isEdited: false,
+          content: content,
+          creationDateTime: DateTime.now(),
+          isDeleted: false,
+        );
 
-      if (replyingTo.value != null) {
         await tablesDB.createRow(
           databaseId: masterDatabaseId,
-          tableId: chatMessageReplyTableId,
+          tableId: chatMessagesTableId,
           rowId: messageId,
-          data: replyingTo.value!.toJson(),
+          data: message.toJsonForUpload(),
         );
+
+        if (replyingTo.value != null) {
+          await tablesDB.createRow(
+            databaseId: masterDatabaseId,
+            tableId: chatMessageReplyTableId,
+            rowId: messageId,
+            data: replyingTo.value!.toJson(),
+          );
+        }
       }
+
       if (appwriteUpcommingRoom != null) {
         log('Sending notification for sent message');
         var body = json.encode({
           'roomId': appwriteUpcommingRoom?.id,
           'payload': {
             'title': 'Message received in ${appwriteUpcommingRoom?.name}',
-            'body': '${message.creatorName} said: ${message.content}',
+            'body':
+                '${user.displayName} said: ${content}',
           },
         });
         var results = await functions.createExecution(
@@ -155,15 +225,13 @@ class RoomChatController extends GetxController {
         );
         log(results.status.name);
       }
-      message.replyTo = replyingTo.value;
 
-      // messages.add(message);
       replyingTo.value = null;
     } catch (e) {
       log('Error sending message: $e');
       return;
     }
-    log('Message sed\nt');
+    log('Message sent\n');
   }
 
   Future<void> editMessage(String messageId, String newContent) async {
@@ -206,6 +274,44 @@ class RoomChatController extends GetxController {
     }
   }
 
+  Future<void> muteUser(String targetUid) async {
+    if (!isAdmin || chatFunctionId.isEmpty) return;
+    try {
+      await functions.createExecution(
+        functionId: chatFunctionId,
+        body: json.encode({
+          'action': 'mute',
+          'roomId': _roomId,
+          'targetUid': targetUid,
+          'moderatorId': requireCurrentAuthUser.uid,
+          'isMuted': true,
+        }),
+      );
+    } catch (e) {
+      log('Error muting user: $e');
+      rethrow;
+    }
+  }
+
+  Future<void> unmuteUser(String targetUid) async {
+    if (!isAdmin || chatFunctionId.isEmpty) return;
+    try {
+      await functions.createExecution(
+        functionId: chatFunctionId,
+        body: json.encode({
+          'action': 'mute',
+          'roomId': _roomId,
+          'targetUid': targetUid,
+          'moderatorId': requireCurrentAuthUser.uid,
+          'isMuted': false,
+        }),
+      );
+    } catch (e) {
+      log('Error unmuting user: $e');
+      rethrow;
+    }
+  }
+
   void setReplyingTo(Message message) {
     replyingTo.value = ReplyTo(
       messageId: message.messageId,
@@ -228,7 +334,7 @@ class RoomChatController extends GetxController {
       subscription?.stream.listen((data) async {
         if (data.payload.isNotEmpty) {
           String roomId = data.payload['roomId'];
-          if (roomId == (appwriteRoom?.id ?? appwriteUpcommingRoom!.id)) {
+          if (roomId == _roomId) {
             String docId = data.payload['\$id'];
             String action = data.events.first.substring(
               channel.length + 1 + docId.length + 1,
@@ -246,11 +352,10 @@ class RoomChatController extends GetxController {
                 replyTo = ReplyTo.fromJson(replyToDoc.data);
               } catch (e) {
                 if (e is AppwriteException && e.code == 404) {
-                  // If replyTo document not found, set it to null
                   replyTo = null;
                 } else {
                   log("Error fetching replyTo document: ${e.toString()}");
-                  rethrow; // Rethrow if it's a different error
+                  rethrow;
                 }
               }
               newMessage.replyTo = replyTo;

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -93,6 +93,10 @@ const String sendMessageNotificationFunctionID = "65368a58ef47cf6861206";
 const String sendStoryNotificationFunctionID = "68b241f500012870fca3";
 const String startFriendCallFunctionID = "68b76fe00027c243610e";
 
+// Chat cloud function - set after deploying functions/chat/ from Resonate-Backend
+const String chatFunctionId = "";
+const String chatMutesTableId = ""; // TODO: Set after creating chatMutes collection
+
 const String emailVerificationDatabaseID = "64a7bfd6b09121548bfe";
 const String verificationTableID = "64a7c0100eabfe8d3844";
 

--- a/lib/views/screens/room_chat_screen.dart
+++ b/lib/views/screens/room_chat_screen.dart
@@ -56,7 +56,6 @@ class _RoomChatScreenState extends State<RoomChatScreen> {
 
     loadMessagesFuture = chatController.loadMessages();
 
-    // Listen to changes in messages and scroll to bottom when new messages are added
     ever(chatController.messages, (messages) {
       if (messages.isNotEmpty) {
         scrollToBottom();
@@ -82,12 +81,26 @@ class _RoomChatScreenState extends State<RoomChatScreen> {
         ),
         title: const Text('Room Chat'),
         centerTitle: true,
-        actions: [
-          IconButton(icon: const Icon(Icons.more_vert), onPressed: () {}),
-        ],
       ),
       body: Column(
         children: [
+          Obx(() {
+            if (chatController.isMuted.value) {
+              return MaterialBanner(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                content: const Text('You are muted in this room'),
+                leading: const Icon(Icons.volume_off, color: Colors.red),
+                backgroundColor: Colors.red.shade50,
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('DISMISS'),
+                  ),
+                ],
+              );
+            }
+            return const SizedBox.shrink();
+          }),
           Expanded(
             child: FutureBuilder(
               future: loadMessagesFuture,
@@ -97,7 +110,6 @@ class _RoomChatScreenState extends State<RoomChatScreen> {
                 } else if (asyncSnapshot.hasError) {
                   return Center(child: Text('Error: ${asyncSnapshot.error}'));
                 } else {
-                  // Scroll to bottom after messages are loaded
                   WidgetsBinding.instance.addPostFrameCallback((_) {
                     scrollToBottom();
                   });
@@ -133,18 +145,35 @@ class _RoomChatScreenState extends State<RoomChatScreen> {
                               );
                             }
                           },
+                          onMuteUser: chatController.isAdmin
+                              ? (String targetUid) async {
+                                  try {
+                                    await chatController.muteUser(targetUid);
+                                    customSnackbar(
+                                      AppLocalizations.of(context)!.success,
+                                      'User muted',
+                                      LogType.success,
+                                    );
+                                  } catch (e) {
+                                    customSnackbar(
+                                      AppLocalizations.of(context)!.error,
+                                      'Failed to mute user',
+                                      LogType.error,
+                                    );
+                                  }
+                                }
+                              : null,
                           replytoMessage: (Message message) =>
                               chatController.setReplyingTo(message),
                           canEdit:
                               requireCurrentAuthUser.uid ==
-                                  chatController.messages[index].creatorId &&
-                              !chatController.messages[index].isDeleted &&
-                              !chatController.messages[index].isEdited,
-
+                                      chatController.messages[index].creatorId &&
+                                  !chatController.messages[index].isDeleted &&
+                                  !chatController.messages[index].isEdited,
                           canDelete:
                               requireCurrentAuthUser.uid ==
-                                  chatController.messages[index].creatorId &&
-                              !chatController.messages[index].isDeleted,
+                                      chatController.messages[index].creatorId &&
+                                  !chatController.messages[index].isDeleted,
                         );
                       },
                     ),
@@ -166,6 +195,7 @@ class ChatMessageItem extends StatefulWidget {
   final void Function(String) onEditMessage;
   final void Function(Message) replytoMessage;
   final void Function(String) onDeleteMessage;
+  final void Function(String)? onMuteUser;
   final bool canDelete;
   final bool canEdit;
 
@@ -177,6 +207,7 @@ class ChatMessageItem extends StatefulWidget {
     required this.replytoMessage,
     required this.canEdit,
     required this.onDeleteMessage,
+    this.onMuteUser,
     required this.canDelete,
   });
 
@@ -240,21 +271,28 @@ class ChatMessageItemState extends State<ChatMessageItem> {
           child: Wrap(
             children: [
               if (widget.canDelete)
-                ///delete option
                 ListTile(
                   leading: Icon(
                     Icons.delete,
                     color: Theme.of(context).colorScheme.error,
                   ),
                   title: Text(AppLocalizations.of(context)!.delete),
-
                   onTap: () {
                     Navigator.pop(context);
                     _confirmDelete(context);
                   },
                 ),
-
-              ///cancel option
+              if (widget.onMuteUser != null &&
+                  widget.message.creatorId !=
+                      requireCurrentAuthUser.uid)
+                ListTile(
+                  leading: const Icon(Icons.volume_off),
+                  title: const Text('Mute user'),
+                  onTap: () {
+                    Navigator.pop(context);
+                    widget.onMuteUser!(widget.message.creatorId);
+                  },
+                ),
               ListTile(
                 leading: const Icon(Icons.close),
                 title: Text(AppLocalizations.of(context)!.cancel),
@@ -305,17 +343,16 @@ class ChatMessageItemState extends State<ChatMessageItem> {
                 } else if (_dragOffset + details.delta.dx > 100) {
                   _dragOffset = 100;
                 } else if (_dragOffset + details.delta.dx < 0) {
-                  _dragOffset = 0.0; // Reset if dragging left
+                  _dragOffset = 0.0;
                 }
                 setState(() {});
               },
               onHorizontalDragEnd: (details) {
                 if (_dragOffset > 70) {
-                  // Detected swipe from left to right
                   widget.replytoMessage(widget.message);
                 }
                 setState(() {
-                  _dragOffset = 0.0; // Reset offset after swipe
+                  _dragOffset = 0.0;
                 });
               },
               onDoubleTap: widget.canEdit ? startEditing : null,
@@ -406,7 +443,6 @@ class ChatMessageItemState extends State<ChatMessageItem> {
                                       ),
                                     ),
                                   if (isEditing)
-                                    ///the message to edit it AND the message is not deleted
                                     Focus(
                                       onKeyEvent: (node, event) {
                                         if (event.logicalKey ==
@@ -436,7 +472,6 @@ class ChatMessageItemState extends State<ChatMessageItem> {
                                       ),
                                     )
                                   else if (widget.message.isDeleted)
-                                    ///The message has been deleted (`isDeleted = true`)
                                     Text(
                                       AppLocalizations.of(
                                         context,
@@ -579,18 +614,21 @@ class ChatInputField extends StatelessWidget {
                     Expanded(
                       child: TextField(
                         controller: _messageController,
+                        enabled: !chatController.isMuted.value,
                         onSubmitted: (value) async {
-                          if (_messageController.text.isNotEmpty) {
+                          if (_messageController.text.isNotEmpty &&
+                              !chatController.isMuted.value) {
                             await chatController.sendMessage(
                               _messageController.text,
                             );
                             _messageController.clear();
-                            // Clear reply if user sends a message
                             chatController.clearReplyingTo();
                           }
                         },
                         decoration: InputDecoration(
-                          hintText: 'Say Something',
+                          hintText: chatController.isMuted.value
+                              ? 'You are muted'
+                              : 'Say Something',
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(20),
                             borderSide: BorderSide.none,
@@ -606,16 +644,17 @@ class ChatInputField extends StatelessWidget {
                     const SizedBox(width: 10),
                     IconButton(
                       icon: const Icon(Icons.send),
-                      onPressed: () async {
-                        if (_messageController.text.isNotEmpty) {
-                          await chatController.sendMessage(
-                            _messageController.text,
-                          );
-                          _messageController.clear();
-                          // Clear reply if user sends a message
-                          chatController.clearReplyingTo();
-                        }
-                      },
+                      onPressed: chatController.isMuted.value
+                          ? null
+                          : () async {
+                              if (_messageController.text.isNotEmpty) {
+                                await chatController.sendMessage(
+                                  _messageController.text,
+                                );
+                                _messageController.clear();
+                                chatController.clearReplyingTo();
+                              }
+                            },
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Description

Closes #730

Integrates the in-room chat backend (Resonate-Backend PR #173) into the Flutter frontend, and adds mute moderation support.

### Changes

**lib/controllers/room_chat_controller.dart**
- `sendMessage()`: Uses cloud function for server-validated sends (participant check, mute check) with direct DB fallback
- `deleteMessage()`: Uses cloud function for authorized deletion (creator or admin) with direct DB fallback
- New `muteUser(targetUid)`: Admin-only mute via cloud function
- New `unmuteUser(targetUid)`: Admin-only unmute via cloud function 
- New `checkMuteStatus()`: Checks if current user is muted on chat open
- New `isMuted` observable for reactive UI
- New `isAdmin` getter

**lib/views/screens/room_chat_screen.dart**
- Muted banner at top of chat when user is muted
- Input field disabled with \"You are muted\" hint when muted
- Send button disabled when muted
- \"Mute user\" option in long-press context menu (admin only, excludes self)
- Admin check uses existing `appwriteRoom.isUserAdmin`

**lib/utils/constants.dart**
- Added `chatFunctionId` and `chatMutesTableId` constants

### Setup

After deploying the chat cloud function (Resonate-Backend PR #173), set `chatFunctionId` in constants.dart to the deployed function ID.

### Related

- Backend PR: AOSSIE-Org/Resonate-Backend#173