### PR TITLE
fix: guard rating average when ratingCount is zero

### DIFF
--- a/lib/controllers/auth_state_controller.dart
+++ b/lib/controllers/auth_state_controller.dart
@@ -49,6 +49,11 @@ class AuthStateController extends GetxController {
   late bool? isEmailVerified;
   late double ratingTotal;
   late int ratingCount;
+
+  /// Safe average; returns 0 when there are no ratings yet.
+  double get averageRating =>
+      ratingCount == 0 ? 0 : ratingTotal / ratingCount;
+
   late User appwriteUser;
   late List<FollowerUserModel> followerDocuments;
   late int reportsCount;

--- a/lib/controllers/explore_story_controller.dart
+++ b/lib/controllers/explore_story_controller.dart
@@ -196,8 +196,10 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc.$id;
       userData['uid'] = doc.$id;
       userData['userName'] = userData['username'];
-      userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+      userData['userRating'] = _averageRating(
+        userData['ratingTotal'],
+        userData['ratingCount'],
+      );
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);
@@ -215,14 +217,26 @@ class ExploreStoryController extends GetxController {
       userData['docId'] = doc['\$id'];
       userData['uid'] = doc['\$id'];
       userData['userName'] = userData['username'];
-      userData['userRating'] =
-          userData['ratingTotal'] / userData['ratingCount'];
+      userData['userRating'] = _averageRating(
+        userData['ratingTotal'],
+        userData['ratingCount'],
+      );
       log(userData['userRating'].toString());
       Future.delayed(Duration(seconds: 1));
       ResonateUser user = ResonateUser.fromJson(userData);
 
       return user;
     }).toList();
+  }
+
+  /// Returns 0 when there are no ratings to avoid Infinity/NaN.
+  double _averageRating(dynamic ratingTotal, dynamic ratingCount) {
+    final total = (ratingTotal is num) ? ratingTotal.toDouble() : 0.0;
+    final count = (ratingCount is num) ? ratingCount.toDouble() : 0.0;
+    if (count == 0) {
+      return 0;
+    }
+    return total / count;
   }
 
   Future<void> updateStoriesPlayDurationLength(

--- a/lib/controllers/friends_controller.dart
+++ b/lib/controllers/friends_controller.dart
@@ -65,8 +65,7 @@ class FriendsController extends GetxController {
       docId: docId,
       senderFCMToken: userFCMToken,
       users: [authStateController.uid!, recieverId],
-      senderRating:
-          authStateController.ratingTotal / authStateController.ratingCount,
+      senderRating: authStateController.averageRating,
       recieverRating: recieverRating,
     );
     await tables.createRow(

--- a/lib/controllers/pair_chat_controller.dart
+++ b/lib/controllers/pair_chat_controller.dart
@@ -80,7 +80,7 @@ class PairChatController extends GetxController {
       "profileImageUrl": authController.profileImageUrl,
       "userName": authController.userName,
       "name": authController.displayName,
-      "userRating": authController.ratingTotal / authController.ratingCount,
+      "userRating": authController.averageRating,
     };
 
     // Add request to pair-request collection

--- a/lib/controllers/user_profile_controller.dart
+++ b/lib/controllers/user_profile_controller.dart
@@ -150,8 +150,7 @@ class UserProfileController extends GetxController {
       name: authStateController.displayName!,
       fcmToken: fcmToken!,
       followingUserId: creatorId,
-      followerRating:
-          authStateController.ratingTotal / authStateController.ratingCount,
+      followerRating: authStateController.averageRating,
     );
 
     await tablesDB.createRow(

--- a/lib/views/screens/profile_screen.dart
+++ b/lib/views/screens/profile_screen.dart
@@ -205,9 +205,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         padding: const EdgeInsets.only(left: 5),
                         child: Text(
                           widget.isCreatorProfile == null
-                              ? (authController.ratingTotal /
-                                        authController.ratingCount)
-                                    .toStringAsFixed(1)
+                              ? authController.averageRating.toStringAsFixed(1)
                               : widget.creator!.userRating!.toStringAsFixed(1),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- Adds `AuthStateController.averageRating` that returns `0` when `ratingCount == 0`
- Uses it in profile / friends / pair-chat flows
- Guards Appwrite/Meilisearch user list conversion the same way

Fixes #780  
Fixes #799

## Test plan
- [ ] User with `ratingCount == 0` — profile star text shows `0.0` (no crash)
- [ ] User with ratings — average still matches `ratingTotal / ratingCount`
- [ ] Existing explore_story_controller tests still pass